### PR TITLE
Add interface sorting support.

### DIFF
--- a/netutils/interface.py
+++ b/netutils/interface.py
@@ -298,7 +298,7 @@ def insert_nodes(node: t.Dict[CharacterClass, t.Any], values: t.Tuple[CharacterC
 
     This function mutates the node dict in place.  A terminal value needs to be
     preserved from overwrites, hence the one-way switch in CharacterClass.  These
-    clases are compared only by weight and value, so dict updates are a little tricky.
+    classes are compared only by weight and value, so dict updates are a little tricky.
     We need to pop the key and add a new pointer, or `terminal` will not be updated
     in the new entry.
     """

--- a/netutils/interface.py
+++ b/netutils/interface.py
@@ -266,7 +266,7 @@ def _CCfail(*args):  # pylint: disable=C0103
     raise ValueError(f"unknown character '{args[0][0]}'.")
 
 
-def split_interface_tuple(interface: str) -> t.Tuple[CharacterClass, ...]:
+def _split_interface_tuple(interface: str) -> t.Tuple[CharacterClass, ...]:
     """Parser-combinator hack, keeping dependencies light."""
     idx = 0
     # we mutate tail's reference, so mypy needs help
@@ -293,7 +293,7 @@ def split_interface_tuple(interface: str) -> t.Tuple[CharacterClass, ...]:
     return tail
 
 
-def insert_nodes(node: t.Dict[CharacterClass, t.Any], values: t.Tuple[CharacterClass, ...]) -> None:
+def _insert_nodes(node: t.Dict[CharacterClass, t.Any], values: t.Tuple[CharacterClass, ...]) -> None:
     """Recursively updates a tree from a list of values.
 
     This function mutates the node dict in place.  A terminal value needs to be
@@ -312,7 +312,7 @@ def insert_nodes(node: t.Dict[CharacterClass, t.Any], values: t.Tuple[CharacterC
         key.terminal = True
         node.pop(key)
         node[key] = val
-    insert_nodes(node[key], values[1:])
+    _insert_nodes(node[key], values[1:])
 
 
 def iter_tree(node: t.Dict[CharacterClass, t.Any], parents: t.List[CharacterClass]) -> t.Generator[str, None, None]:
@@ -350,5 +350,5 @@ def sort_interface_list(interfaces: t.List[str]) -> t.List[str]:
     """
     root: t.Dict[CharacterClass, t.Any] = {}
     for ifname in interfaces:
-        insert_nodes(root, split_interface_tuple(ifname))
+        _insert_nodes(root, _split_interface_tuple(ifname))
     return list(iter_tree(root, []))

--- a/netutils/interface.py
+++ b/netutils/interface.py
@@ -334,7 +334,10 @@ def sort_interface_list(interfaces: t.List[str]) -> t.List[str]:
     """This function sorts and cleans a list of interfaces.
 
     Note that a new list of interfaces is returned and that duplicates
-    are removed.
+        >>> sort_interface_list(["Gi1/0/1", "Gi1/0/3", "Gi1/0/3.100", "Gi1/0/2", "Gi1/0/2.50", "Gi2/0/2", "Po40", "Po160", "Lo10"])
+        ['Gi1/0/1', 'Gi1/0/2', 'Gi1/0/2.50', 'Gi1/0/3', 'Gi1/0/3.100', 'Gi2/0/2', 'Lo10', 'Po40', 'Po160']
+        >>> sort_interface_list(['GigabitEthernet1/0/1', 'GigabitEthernet1/0/3', 'GigabitEthernet1/0/2', "GigabitEthernett3/0/5", 'GigabitEthernet3/0/7', 'GigabitEthernet2/0/8.5',  'Port-channel40', 'Vlan20', 'Loopback10'])
+        ['GigabitEthernet1/0/1', 'GigabitEthernet1/0/2', 'GigabitEthernet1/0/3', 'GigabitEthernet2/0/8.5', 'GigabitEthernet3/0/7', 'GigabitEthernett3/0/5', 'Loopback10', 'Port-channel40', 'Vlan20']
     """
     root: t.Dict[CharacterClass, t.Any] = {}
     for ifname in interfaces:

--- a/netutils/interface.py
+++ b/netutils/interface.py
@@ -334,6 +334,15 @@ def sort_interface_list(interfaces: t.List[str]) -> t.List[str]:
     """This function sorts and cleans a list of interfaces.
 
     Note that a new list of interfaces is returned and that duplicates
+    nodes are removed.
+
+    Args:
+        interfaces (list[str]): A list of interfaces to be sorted.  The input list is not mutated by this function.
+
+    Returns:
+        list[str]: A **new** sorted, unique list elements from the input.
+
+    Example:
         >>> sort_interface_list(["Gi1/0/1", "Gi1/0/3", "Gi1/0/3.100", "Gi1/0/2", "Gi1/0/2.50", "Gi2/0/2", "Po40", "Po160", "Lo10"])
         ['Gi1/0/1', 'Gi1/0/2', 'Gi1/0/2.50', 'Gi1/0/3', 'Gi1/0/3.100', 'Gi2/0/2', 'Lo10', 'Po40', 'Po160']
         >>> sort_interface_list(['GigabitEthernet1/0/1', 'GigabitEthernet1/0/3', 'GigabitEthernet1/0/2', "GigabitEthernett3/0/5", 'GigabitEthernet3/0/7', 'GigabitEthernet2/0/8.5',  'Port-channel40', 'Vlan20', 'Loopback10'])

--- a/tests/unit/test_interface.py
+++ b/tests/unit/test_interface.py
@@ -234,7 +234,7 @@ def test_interface_range_expansion(data):
 @pytest.mark.parametrize("data", BAD_INTERFACE_NAMES)
 def test_split_interface_tuple_fails(data):
     with pytest.raises(ValueError):
-        interface.split_interface_tuple(data)
+        interface._split_interface_tuple(data)  # pylint: disable=W0212
 
 
 def test_interface_sort_empty():

--- a/tests/unit/test_interface.py
+++ b/tests/unit/test_interface.py
@@ -98,6 +98,106 @@ INTERFACE_EXPANSION = [
     {"sent": "[1,2]/0/[1-2]", "received": ["1/0/1", "1/0/2", "2/0/1", "2/0/2"]},
 ]
 
+INTERFACE_SORT = [
+    {"sent": [], "received": []},
+    {"sent": ["Fa0/0/1.200", "Fa0/0/1.200", "Fa0/0/1.200"], "received": ["Fa0/0/1.200"]},
+    {
+        "sent": [
+            "Fa0/0/2.200",
+            "Fa1/0/1.100",
+            "Fa1/0.100",
+            "Gi1/1",
+            "Gi0/1",
+            "Gi0/0/1",
+            "Gi1/0/2",
+            "Vlan42",
+            "Te/42",
+            "loopback99",
+            "Port-channel75",
+            "Gi1/0/1",
+            "Fa0/0/2",
+            "Fa0/0/1",
+            "Fa0/0/1.101",
+            "Fa0/0/1.100",
+            "Fa0/0/1.10",
+            "Fa0/0/1.500",
+            "Fa0/0/1.999",
+            "Gi/42",
+            "Loopback101",
+            "Loopback102",
+            "Loopback98",
+            "Loopback99",
+            "Port-channel160",
+            "Port-channel40",
+            "Fa0/0/1.4",
+            "Fa42",
+            "Gi1/0/3",
+            "Gi1/0/3.100",
+            "Fa1",
+            "Gi1/0/2",
+            "Gi1/0/2.50",
+            "Zf.42",
+            "Fa1.42",
+            "Po40",
+            "Po160",
+            "Lo10",
+            "Fa1/42",
+            "Gi0/0/2",
+            "Gi1/0/1",
+            "Te1/0/1",
+        ],
+        "received": [
+            "Fa0/0/1",
+            "Fa0/0/1.4",
+            "Fa0/0/1.10",
+            "Fa0/0/1.100",
+            "Fa0/0/1.101",
+            "Fa0/0/1.500",
+            "Fa0/0/1.999",
+            "Fa0/0/2",
+            "Fa0/0/2.200",
+            "Fa1",
+            "Fa1.42",
+            "Fa1/0.100",
+            "Fa1/0/1.100",
+            "Fa1/42",
+            "Fa42",
+            "Gi0/0/1",
+            "Gi0/0/2",
+            "Gi0/1",
+            "Gi1/0/1",
+            "Gi1/0/2",
+            "Gi1/0/2.50",
+            "Gi1/0/3",
+            "Gi1/0/3.100",
+            "Gi1/1",
+            "Gi/42",
+            "Lo10",
+            "Loopback98",
+            "Loopback99",
+            "Loopback101",
+            "Loopback102",
+            "Po40",
+            "Po160",
+            "Port-channel40",
+            "Port-channel75",
+            "Port-channel160",
+            "Te1/0/1",
+            "Te/42",
+            "Vlan42",
+            "Zf.42",
+            "loopback99",
+        ],
+    },
+]
+
+BAD_INTERFACE_NAMES = [
+    "fa?",
+    "Gi1^",
+    "Fa0/0*/42",
+    "Te42/55.32/77@99",
+]
+
 
 @pytest.mark.parametrize("data", SPLIT_INTERFACE)
 def test_split_interface(data):
@@ -129,3 +229,25 @@ def test_abbreviated_interface_name_failure():
 @pytest.mark.parametrize("data", INTERFACE_EXPANSION)
 def test_interface_range_expansion(data):
     assert interface.interface_range_expansion(data["sent"]) == data["received"]
+
+
+@pytest.mark.parametrize("data", BAD_INTERFACE_NAMES)
+def test_split_interface_tuple_fails(data):
+    with pytest.raises(ValueError):
+        interface.split_interface_tuple(data)
+
+
+def test_interface_sort_empty():
+    assert interface.sort_interface_list([]) == []
+
+
+@pytest.mark.parametrize("data", INTERFACE_SORT)
+def test_interface_sort_prune(data):
+    """Assert that duplicate nodes are pruned from the tree."""
+    assert set(interface.sort_interface_list(data["sent"])) == set(data["received"])
+
+
+@pytest.mark.parametrize("data", INTERFACE_SORT)
+def test_interface_sort_order(data):
+    """Assert that the tree iterates in canonical order."""
+    assert interface.sort_interface_list(data["sent"]) == data["received"]


### PR DESCRIPTION
@qduk I have refactored the gist I sent (thank you for pointing out how broken that was! :grimacing:).  I finally put together a proper PR with all the test cases I could find.  This is a bit more complexity, but taking the "character class" approach allows future modifications to completely customize the sorting logic based on arbitrary groups of characters.  Sorts happen first by `CharacterClass.weight`, and secondly by whatever logic you like, for example, casting to `int` for the `CCInt` class.