### PR TITLE
Update NAPALM maps

### DIFF
--- a/netutils/lib_mapper.py
+++ b/netutils/lib_mapper.py
@@ -124,11 +124,16 @@ NTCTEMPLATES_LIB_MAPPER["huawei_vrp"] = "huawei_vrp"
 NTCTEMPLATES_LIB_MAPPER["vmware_nsxv"] = "vmware_nsxv"
 
 NAPALM_LIB_MAPPER = {
+    "asa": "cisco_asa",
+    "cisco_wlc_ssh": "cisco_wlc",
     "eos": "arista_eos",
+    "fortios": "fortinet",
     "ios": "cisco_ios",
     "nxos": "cisco_nxos",
     "iosxr": "cisco_xr",
     "junos": "juniper_junos",
+    "sros": "nokia_sros",
+    "vyos": "brocade_vyos",
 }
 
 PYNTC_LIB_MAPPER = {
@@ -190,10 +195,15 @@ SCRAPLI_LIB_MAPPER = {
 
 NAPALM_LIB_MAPPER_REVERSE = {
     "arista_eos": "eos",
+    "brocade_vyos": "vyos",
+    "cisco_asa": "asa",
     "cisco_ios": "ios",
     "cisco_nxos": "nxos",
     "cisco_xr": "iosxr",
+    "cisco_wlc": "cisco_wlc_ssh",
+    "fortinet": "fortios",
     "juniper_junos": "junos",
+    "sros": "nokia_sros",
 }
 
 PYNTC_LIB_MAPPER_REVERSE = {

--- a/netutils/lib_mapper.py
+++ b/netutils/lib_mapper.py
@@ -207,7 +207,7 @@ NAPALM_LIB_MAPPER_REVERSE = {
     "huawei_vrp": "huawei",
     "juniper_junos": "junos",
     "paloalto_panos": "panos",
-    "sros": "nokia_sros",
+    "nokia_sros": "sros",
 }
 
 PYNTC_LIB_MAPPER_REVERSE = {

--- a/netutils/lib_mapper.py
+++ b/netutils/lib_mapper.py
@@ -128,10 +128,12 @@ NAPALM_LIB_MAPPER = {
     "cisco_wlc_ssh": "cisco_wlc",
     "eos": "arista_eos",
     "fortios": "fortinet",
+    "huawei": "huawei_vrp",
     "ios": "cisco_ios",
     "nxos": "cisco_nxos",
     "iosxr": "cisco_xr",
     "junos": "juniper_junos",
+    "panos": "paloalto_panos",
     "sros": "nokia_sros",
     "vyos": "brocade_vyos",
 }
@@ -202,7 +204,9 @@ NAPALM_LIB_MAPPER_REVERSE = {
     "cisco_xr": "iosxr",
     "cisco_wlc": "cisco_wlc_ssh",
     "fortinet": "fortios",
+    "huawei_vrp": "huawei",
     "juniper_junos": "junos",
+    "paloalto_panos": "panos",
     "sros": "nokia_sros",
 }
 


### PR DESCRIPTION
This PR adds some mappings to the NAPALM lib maps for the community drivers including Cisco ASA, Cisco WLC, Fortinet FortiOS, Nokia SrOS, and Brocade VyOS.