### PR TITLE
Add failing test for IOS banner

### DIFF
--- a/tests/unit/mock/config/compliance/compliance/cisco_ios/ios_basic_backup.txt
+++ b/tests/unit/mock/config/compliance/compliance/cisco_ios/ios_basic_backup.txt
@@ -10,8 +10,8 @@ access-list 1 permit 10.10.20.20
 ntp server 192.168.0.100
 ntp server 192.168.0.101
 !
-banner login ^C
+banner login ^
 ******************
     TEST BANNER
 ******************
-^C
+^

--- a/tests/unit/mock/config/compliance/compliance/cisco_ios/ios_basic_backup.txt
+++ b/tests/unit/mock/config/compliance/compliance/cisco_ios/ios_basic_backup.txt
@@ -9,3 +9,9 @@ access-list 1 permit 10.10.20.20
 !
 ntp server 192.168.0.100
 ntp server 192.168.0.101
+!
+banner login ^C
+******************
+    TEST BANNER
+******************
+^C

--- a/tests/unit/mock/config/compliance/compliance/cisco_ios/ios_basic_feature.py
+++ b/tests/unit/mock/config/compliance/compliance/cisco_ios/ios_basic_feature.py
@@ -2,4 +2,5 @@ features = [
     {"name": "bgp", "ordered": True, "section": ["router bgp "]},
     {"name": "snmp", "ordered": True, "section": ["snmp-server "]},
     {"name": "ntp", "ordered": False, "section": ["ntp server "]},
+    {"name": "banner", "ordered": True, "section": ["banner "]},
 ]

--- a/tests/unit/mock/config/compliance/compliance/cisco_ios/ios_basic_intended.txt
+++ b/tests/unit/mock/config/compliance/compliance/cisco_ios/ios_basic_intended.txt
@@ -9,3 +9,9 @@ access-list 1 permit 10.10.20.20
 !
 ntp server 192.168.0.101
 ntp server 192.168.0.100
+!
+banner login ^
+******************
+    TEST BANNER
+******************
+^

--- a/tests/unit/mock/config/compliance/compliance/cisco_ios/ios_basic_received.json
+++ b/tests/unit/mock/config/compliance/compliance/cisco_ios/ios_basic_received.json
@@ -30,7 +30,7 @@
       "unordered_compliant": true
    },
    "banner": {
-      "actual": "banner login ^C\n******************\n    TEST BANNER\n******************\n^C",
+      "actual": "banner login ^\n******************\n    TEST BANNER\n******************\n^",
       "cannot_parse": true,
       "compliant": true,
       "extra": "",

--- a/tests/unit/mock/config/compliance/compliance/cisco_ios/ios_basic_received.json
+++ b/tests/unit/mock/config/compliance/compliance/cisco_ios/ios_basic_received.json
@@ -28,5 +28,15 @@
       "missing": "",
       "ordered_compliant": false,
       "unordered_compliant": true
-   }
+   },
+   "banner": {
+      "actual": "banner login ^C\n******************\n    TEST BANNER\n******************\n^C",
+      "cannot_parse": true,
+      "compliant": true,
+      "extra": "",
+      "intended": "banner login ^\n******************\n    TEST BANNER\n******************\n^",
+      "missing": "",
+      "ordered_compliant": true,
+      "unordered_compliant": true
+   }   
 }


### PR DESCRIPTION
This PR adds a failing test for an IOS banner.

It's objective is to draw attention to an issue parsing an IOS banner containing the `^` character as a banner delimiter.

The backup configuration is intentionally different to the intended to replicate the characters the Cisco IOS platform inserts when configuration is pasted into the IOS terminal. 