### PR TITLE
Fix the CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
     env:
       PYTHON_VER: "${{ matrix.python-version }}"
       IMAGE_NAME: "netutils"
-    steps:    
+    steps:
       - name: "Check out repository code"
         uses: "actions/checkout@v2"
       - name: "Setup environment"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 ---
 name: "CI"
-on:  # yamllint disable
+on:  # yamllint disable-line rule:truthy
   - "push"
   - "pull_request"
 
@@ -84,8 +84,6 @@ jobs:
         uses: "networktocode/gh-action-setup-poetry-environment@v2"
       - name: "Get image version"
         run: "echo IMAGE_VER=`poetry version -s`-py${{ matrix.python-version }} >> $GITHUB_ENV"
-      - name: "Debug"
-        run: "echo $IMAGE_VER"
       - name: "Set up Docker Buildx"
         id: "buildx"
         uses: "docker/setup-buildx-action@v1"
@@ -101,32 +99,11 @@ jobs:
           cache-to: "type=gha,scope=${{ env.IMAGE_NAME }}-${{ env.IMAGE_VER }}-py${{ matrix.python-version }}"
           build-args: |
             PYTHON_VER=${{ env.PYTHON_VER }}
-
-
-    #   - name: "Create tmp docker dir"
-    #     run: "mkdir /tmp/docker"
-    #   - name: "Cache Docker images"
-    #     uses: "actions/cache@v2"
-    #     id: "cached-docker-images"
-    #     with:
-    #       path: "/tmp/docker"
-    #       key: "${{ runner.os }}-docker-${{ matrix.python-version }}-${{ hashFiles('./Dockerfile') }}"
-    #   - name: "Build Container"
-    #     if: "steps.cached-docker-images.outputs.cache-hit != 'true'"
-    #     run: "poetry run invoke build"
-    #   - name: "Show Docker images"
-    #     if: "steps.cached-docker-images.outputs.cache-hit != 'true'"
-    #     run: "docker image ls"
-    #   - name: "Save the Docker image"
-    #     if: "steps.cached-docker-images.outputs.cache-hit != 'true'"
-    #     run: "docker save `echo ${IMAGE_NAME}`:`poetry version -s`-py${{ matrix.python-version }} > /tmp/docker/netutils-py${{ matrix.python-version }}.tar"
-    #   - name: "Show files"
-    #     run: "ls -al /tmp/docker"
-    # needs:
-    #   - "bandit"
-    #   - "pydocstyle"
-    #   - "flake8"
-    #   - "yamllint"
+    needs:
+      - "bandit"
+      - "pydocstyle"
+      - "flake8"
+      - "yamllint"
   pylint:
     runs-on: "ubuntu-20.04"
     strategy:
@@ -143,8 +120,6 @@ jobs:
         uses: "networktocode/gh-action-setup-poetry-environment@v2"
       - name: "Get image version"
         run: "echo IMAGE_VER=`poetry version -s`-py${{ matrix.python-version }} >> $GITHUB_ENV"
-      - name: "Debug"
-        run: "echo $IMAGE_VER"
       - name: "Set up Docker Buildx"
         id: "buildx"
         uses: "docker/setup-buildx-action@v1"
@@ -161,23 +136,8 @@ jobs:
           cache-to: "type=gha,scope=${{ env.IMAGE_NAME }}-${{ env.IMAGE_VER }}-py${{ matrix.python-version }}"
           build-args: |
             PYTHON_VER=${{ env.PYTHON_VER }}
-      - name: "Debug"
+      - name: "Debug: Show docker images"
         run: "docker image ls"
-
-
-
-      # - name: "Cache Docker images"
-      #   uses: "actions/cache@v2"
-      #   id: "cached-docker-images"
-      #   with:
-      #     path: "/tmp/docker"
-      #     key: "${{ runner.os }}-docker-${{ matrix.python-version }}-${{ hashFiles('./Dockerfile') }}"
-      # - name: "Load docker image"
-      #   run: "docker load < /tmp/docker/netutils-py${{ matrix.python-version }}.tar"
-      # - name: "Show docker images"
-      #   run: "docker image ls"
-      # - name: "Build Container"
-      #   run: "poetry run invoke build"
       - name: "Linting: Pylint"
         run: "poetry run invoke pylint"
     needs:
@@ -195,18 +155,26 @@ jobs:
         uses: "actions/checkout@v2"
       - name: "Setup environment"
         uses: "networktocode/gh-action-setup-poetry-environment@v2"
-      # - name: "Cache Docker images"
-      #   uses: "actions/cache@v2"
-      #   id: "cached-docker-images"
-      #   with:
-      #     path: "/tmp/docker"
-      #     key: "${{ runner.os }}-docker-${{ matrix.python-version }}-${{ hashFiles('./Dockerfile') }}"
-      # - name: "Load docker image"
-      #   run: "docker load < /tmp/docker/netutils-py${{ matrix.python-version }}.tar"
-      - name: "Build Container"
-        run: "poetry run invoke build"
-      - name: "Linting: Pylint"
-        run: "poetry run invoke pylint"
+      - name: "Get image version"
+        run: "echo IMAGE_VER=`poetry version -s`-py${{ matrix.python-version }} >> $GITHUB_ENV"
+      - name: "Set up Docker Buildx"
+        id: "buildx"
+        uses: "docker/setup-buildx-action@v1"
+      - name: "Load the image from cache"
+        uses: "docker/build-push-action@v2"
+        with:
+          builder: "${{ steps.buildx.outputs.name }}"
+          context: "./"
+          push: false
+          load: true
+          tags: "${{ env.IMAGE_NAME }}:${{ env.IMAGE_VER }}"
+          file: "./Dockerfile"
+          cache-from: "type=gha,scope=${{ env.IMAGE_NAME }}-${{ env.IMAGE_VER }}-py${{ matrix.python-version }}"
+          cache-to: "type=gha,scope=${{ env.IMAGE_NAME }}-${{ env.IMAGE_VER }}-py${{ matrix.python-version }}"
+          build-args: |
+            PYTHON_VER=${{ env.PYTHON_VER }}
+      - name: "Debug: Show docker images"
+        run: "docker image ls"
       - name: "Run Tests"
         run: "poetry run invoke pytest"
     needs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
       - name: "Setup environment"
         uses: "networktocode/gh-action-setup-poetry-environment@v2"
       - name: "Get image version"
-        run: "echo IMAGE_VER=`poetry version -s` >> $GITHUB_ENV"
+        run: "echo IMAGE_VER=`poetry version -s`-py${{ matrix.python-version }} >> $GITHUB_ENV"
       - name: "Debug"
         run: "echo $IMAGE_VER"
       - name: "Set up Docker Buildx"
@@ -95,7 +95,7 @@ jobs:
           builder: "${{ steps.buildx.outputs.name }}"
           context: "./"
           push: false
-          tags: "${{ env.IMAGE_NAME }}:${{ env.IMAGE_VER }}-py${{ matrix.python-version }}"
+          tags: "${{ env.IMAGE_NAME }}:${{ env.IMAGE_VER }}"
           file: "./Dockerfile"
           cache-from: "type=gha,scope=${{ env.IMAGE_NAME }}-${{ env.IMAGE_VER }}-py${{ matrix.python-version }}"
           cache-to: "type=gha,scope=${{ env.IMAGE_NAME }}-${{ env.IMAGE_VER }}-py${{ matrix.python-version }}"
@@ -142,7 +142,7 @@ jobs:
       - name: "Setup environment"
         uses: "networktocode/gh-action-setup-poetry-environment@v2"
       - name: "Get image version"
-        run: "echo IMAGE_VER=`poetry version -s` >> $GITHUB_ENV"
+        run: "echo IMAGE_VER=`poetry version -s`-py${{ matrix.python-version }} >> $GITHUB_ENV"
       - name: "Debug"
         run: "echo $IMAGE_VER"
       - name: "Set up Docker Buildx"
@@ -154,12 +154,15 @@ jobs:
           builder: "${{ steps.buildx.outputs.name }}"
           context: "./"
           push: false
-          tags: "${{ env.IMAGE_NAME }}:${{ env.IMAGE_VER }}-py${{ matrix.python-version }}"
+          load: true
+          tags: "${{ env.IMAGE_NAME }}:${{ env.IMAGE_VER }}"
           file: "./Dockerfile"
           cache-from: "type=gha,scope=${{ env.IMAGE_NAME }}-${{ env.IMAGE_VER }}-py${{ matrix.python-version }}"
           cache-to: "type=gha,scope=${{ env.IMAGE_NAME }}-${{ env.IMAGE_VER }}-py${{ matrix.python-version }}"
           build-args: |
             PYTHON_VER=${{ env.PYTHON_VER }}
+      - name: "Debug"
+        run: "docker image ls"
 
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:  # yamllint disable-line rule:truthy
   - "push"
   - "pull_request"
 
+env:
+  IMAGE_NAME: "netutils"
+
 jobs:
   black:
     runs-on: "ubuntu-20.04"
@@ -76,7 +79,6 @@ jobs:
     runs-on: "ubuntu-20.04"
     env:
       PYTHON_VER: "${{ matrix.python-version }}"
-      IMAGE_NAME: "netutils"
     steps:
       - name: "Check out repository code"
         uses: "actions/checkout@v2"
@@ -112,7 +114,6 @@ jobs:
         python-version: ["3.7"]
     env:
       PYTHON_VER: "${{ matrix.python-version }}"
-      IMAGE_NAME: "netutils"
     steps:
       - name: "Check out repository code"
         uses: "actions/checkout@v2"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,11 +128,14 @@ jobs:
     #   - "flake8"
     #   - "yamllint"
   pylint:
+    runs-on: "ubuntu-20.04"
     strategy:
       fail-fast: true
       matrix:
         python-version: ["3.7"]
-    runs-on: "ubuntu-20.04"
+    env:
+      PYTHON_VER: "${{ matrix.python-version }}"
+      IMAGE_NAME: "netutils"
     steps:    
       - name: "Check out repository code"
         uses: "actions/checkout@v2"
@@ -145,7 +148,7 @@ jobs:
       - name: "Set up Docker Buildx"
         id: "buildx"
         uses: "docker/setup-buildx-action@v1"
-      - name: "Build"
+      - name: "Load the image from cache"
         uses: "docker/build-push-action@v2"
         with:
           builder: "${{ steps.buildx.outputs.name }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,10 +95,10 @@ jobs:
           builder: "${{ steps.buildx.outputs.name }}"
           context: "./"
           push: false
-          tags: "${{ env.IMAGE_NAME }}:${{ IMAGE_VER }}-py${{ matrix.python-version }}"
+          tags: "${{ env.IMAGE_NAME }}:${{ env.IMAGE_VER }}-py${{ matrix.python-version }}"
           file: "./Dockerfile"
-          cache-from: "type=gha,scope=${{ env.IMAGE_NAME }}-${{ IMAGE_VER }}-py${{ matrix.python-version }}"
-          cache-to: "type=gha,scope=${{ env.IMAGE_NAME }}-${{ IMAGE_VER }}-py${{ matrix.python-version }}"
+          cache-from: "type=gha,scope=${{ env.IMAGE_NAME }}-${{ env.IMAGE_VER }}-py${{ matrix.python-version }}"
+          cache-to: "type=gha,scope=${{ env.IMAGE_NAME }}-${{ env.IMAGE_VER }}-py${{ matrix.python-version }}"
           build-args: |
             PYTHON_VER=${{ env.PYTHON_VER }}
 
@@ -151,10 +151,10 @@ jobs:
           builder: "${{ steps.buildx.outputs.name }}"
           context: "./"
           push: false
-          tags: "${{ env.IMAGE_NAME }}:${{ IMAGE_VER }}-py${{ matrix.python-version }}"
+          tags: "${{ env.IMAGE_NAME }}:${{ env.IMAGE_VER }}-py${{ matrix.python-version }}"
           file: "./Dockerfile"
-          cache-from: "type=gha,scope=${{ env.IMAGE_NAME }}-${{ IMAGE_VER }}-py${{ matrix.python-version }}"
-          cache-to: "type=gha,scope=${{ env.IMAGE_NAME }}-${{ IMAGE_VER }}-py${{ matrix.python-version }}"
+          cache-from: "type=gha,scope=${{ env.IMAGE_NAME }}-${{ env.IMAGE_VER }}-py${{ matrix.python-version }}"
+          cache-to: "type=gha,scope=${{ env.IMAGE_NAME }}-${{ env.IMAGE_VER }}-py${{ matrix.python-version }}"
           build-args: |
             PYTHON_VER=${{ env.PYTHON_VER }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,41 +82,84 @@ jobs:
         uses: "actions/checkout@v2"
       - name: "Setup environment"
         uses: "networktocode/gh-action-setup-poetry-environment@v2"
-      - name: "Create tmp docker dir"
-        run: "mkdir /tmp/docker"
-      - name: "Cache Docker images"
-        uses: "actions/cache@v2"
-        id: "cached-docker-images"
+      - name: "Get image version"
+        run: "echo IMAGE_VER=`poetry version -s` >> $GITHUB_ENV"
+      - name: "Debug"
+        run: "echo $IMAGE_VER"
+      - name: "Set up Docker Buildx"
+        id: "buildx"
+        uses: "docker/setup-buildx-action@v1"
+      - name: "Build"
+        uses: "docker/build-push-action@v2"
         with:
-          path: "/tmp/docker"
-          key: "${{ runner.os }}-docker-${{ matrix.python-version }}-${{ hashFiles('./Dockerfile') }}"
-      - name: "Build Container"
-        if: "steps.cached-docker-images.outputs.cache-hit != 'true'"
-        run: "poetry run invoke build"
-      - name: "Show Docker images"
-        if: "steps.cached-docker-images.outputs.cache-hit != 'true'"
-        run: "docker image ls"
-      - name: "Save the Docker image"
-        if: "steps.cached-docker-images.outputs.cache-hit != 'true'"
-        run: "docker save `echo ${IMAGE_NAME}`:`poetry version -s`-py${{ matrix.python-version }} > /tmp/docker/netutils-py${{ matrix.python-version }}.tar"
-      - name: "Show files"
-        run: "ls -al /tmp/docker"
-    needs:
-      - "bandit"
-      - "pydocstyle"
-      - "flake8"
-      - "yamllint"
+          builder: "${{ steps.buildx.outputs.name }}"
+          context: "./"
+          push: false
+          tags: "${{ env.IMAGE_NAME }}:${{ IMAGE_VER }}-py${{ matrix.python-version }}"
+          file: "./Dockerfile"
+          cache-from: "type=gha,scope=${{ env.IMAGE_NAME }}-${{ IMAGE_VER }}-py${{ matrix.python-version }}"
+          cache-to: "type=gha,scope=${{ env.IMAGE_NAME }}-${{ IMAGE_VER }}-py${{ matrix.python-version }}"
+          build-args: |
+            PYTHON_VER=${{ env.PYTHON_VER }}
+
+
+    #   - name: "Create tmp docker dir"
+    #     run: "mkdir /tmp/docker"
+    #   - name: "Cache Docker images"
+    #     uses: "actions/cache@v2"
+    #     id: "cached-docker-images"
+    #     with:
+    #       path: "/tmp/docker"
+    #       key: "${{ runner.os }}-docker-${{ matrix.python-version }}-${{ hashFiles('./Dockerfile') }}"
+    #   - name: "Build Container"
+    #     if: "steps.cached-docker-images.outputs.cache-hit != 'true'"
+    #     run: "poetry run invoke build"
+    #   - name: "Show Docker images"
+    #     if: "steps.cached-docker-images.outputs.cache-hit != 'true'"
+    #     run: "docker image ls"
+    #   - name: "Save the Docker image"
+    #     if: "steps.cached-docker-images.outputs.cache-hit != 'true'"
+    #     run: "docker save `echo ${IMAGE_NAME}`:`poetry version -s`-py${{ matrix.python-version }} > /tmp/docker/netutils-py${{ matrix.python-version }}.tar"
+    #   - name: "Show files"
+    #     run: "ls -al /tmp/docker"
+    # needs:
+    #   - "bandit"
+    #   - "pydocstyle"
+    #   - "flake8"
+    #   - "yamllint"
   pylint:
     strategy:
       fail-fast: true
       matrix:
         python-version: ["3.7"]
     runs-on: "ubuntu-20.04"
-    steps:
+    steps:    
       - name: "Check out repository code"
         uses: "actions/checkout@v2"
       - name: "Setup environment"
         uses: "networktocode/gh-action-setup-poetry-environment@v2"
+      - name: "Get image version"
+        run: "echo IMAGE_VER=`poetry version -s` >> $GITHUB_ENV"
+      - name: "Debug"
+        run: "echo $IMAGE_VER"
+      - name: "Set up Docker Buildx"
+        id: "buildx"
+        uses: "docker/setup-buildx-action@v1"
+      - name: "Build"
+        uses: "docker/build-push-action@v2"
+        with:
+          builder: "${{ steps.buildx.outputs.name }}"
+          context: "./"
+          push: false
+          tags: "${{ env.IMAGE_NAME }}:${{ IMAGE_VER }}-py${{ matrix.python-version }}"
+          file: "./Dockerfile"
+          cache-from: "type=gha,scope=${{ env.IMAGE_NAME }}-${{ IMAGE_VER }}-py${{ matrix.python-version }}"
+          cache-to: "type=gha,scope=${{ env.IMAGE_NAME }}-${{ IMAGE_VER }}-py${{ matrix.python-version }}"
+          build-args: |
+            PYTHON_VER=${{ env.PYTHON_VER }}
+
+
+
       # - name: "Cache Docker images"
       #   uses: "actions/cache@v2"
       #   id: "cached-docker-images"
@@ -127,8 +170,8 @@ jobs:
       #   run: "docker load < /tmp/docker/netutils-py${{ matrix.python-version }}.tar"
       # - name: "Show docker images"
       #   run: "docker image ls"
-      - name: "Build Container"
-        run: "poetry run invoke build"
+      # - name: "Build Container"
+      #   run: "poetry run invoke build"
       - name: "Linting: Pylint"
         run: "poetry run invoke pylint"
     needs:


### PR DESCRIPTION
@itdependsnetworks please review the PR.

The previous implementation was completely wrong. The cache key was set to the `Dockerfile`. So the cache was invalidated only when the `Dockerfile` was changed.

The updated implementation uses the docker layer caching which means that every change in any Docker layer will trigger a new build.

This PR closes #72 .
