### PR TITLE
F5 parser fix for irules with multiline single command lines.

### DIFF
--- a/docs/source/netutils/configs/index.rst
+++ b/docs/source/netutils/configs/index.rst
@@ -17,3 +17,7 @@ Edge Cases
 Fortinet Fortios Parser
 -----------------------
 - In order to support html blocks that exist in Fortios configurations, some preprocessing is executed, this is a regex that specifically grabs everything between quotes after the 'set buffer' sub-command. It's explicitly looking for double quote followed by a newline ("\n) to end the captured data.  This support for html data will not support any other html that doesn't follow this convention.
+
+F5 Parser
+-----------------------
+- The "ltm rule" configuration sections are not uniform nor standardized; therefor, these sections are completely removed from the configuration in a preprocessing event.

--- a/netutils/config/parser.py
+++ b/netutils/config/parser.py
@@ -625,7 +625,30 @@ class F5ConfigParser(BaseBraceConfigParser):
         return final_config
 
     def build_config_relationship(self):
-        r"""Parse text tree of config lines and their parents."""
+        r"""Parse text tree of config lines and their parents.
+        
+        Example:
+            >>> config = '''apm resource webtop-link aShare {
+            ...     application-uri http://funshare.example.com
+            ...     customization-group a_customization_group
+            ... }
+            ... apm sso form-based portal_ext_sso_form_based {
+            ...     form-action /Citrix/Example/ExplicitAuth/LoginAttempt
+            ...     form-field "LoginBtn Log+On
+            ... StateContext "
+            ...     form-password password
+            ...     form-username username
+            ...     passthru true
+            ...     start-uri /Citrix/Example/ExplicitAuth/Login*
+            ...     success-match-type cookie
+            ...     success-match-value CtxsAuthId
+            ... }
+            ... '''
+            >>> 
+            >>> config_tree = F5ConfigParser(config)
+            >>> print(config_tree.build_config_relationship())
+            [ConfigLine(config_line='apm resource webtop-link aShare {', parents=()), ConfigLine(config_line='    application-uri http://funshare.example.com', parents=('apm resource webtop-link aShare {',)), ConfigLine(config_line='    customization-group a_customization_group', parents=('apm resource webtop-link aShare {',)), ConfigLine(config_line='}', parents=('apm resource webtop-link aShare {',)), ConfigLine(config_line='apm sso form-based portal_ext_sso_form_based {', parents=()), ConfigLine(config_line='    form-action /Citrix/Example/ExplicitAuth/LoginAttempt', parents=('apm sso form-based portal_ext_sso_form_based {',)), ConfigLine(config_line='    form-field "LoginBtn Log+On\nStateContext "', parents=('apm sso form-based portal_ext_sso_form_based {',)), ConfigLine(config_line='    form-password password', parents=()), ConfigLine(config_line='    form-username username', parents=()), ConfigLine(config_line='    passthru true', parents=()), ConfigLine(config_line='    start-uri /Citrix/Example/ExplicitAuth/Login*', parents=()), ConfigLine(config_line='    success-match-type cookie', parents=()), ConfigLine(config_line='    success-match-value CtxsAuthId', parents=()), ConfigLine(config_line='}', parents=())]        
+        """
         for line in self.generator_config:
             self.config_lines.append(ConfigLine(line, self._current_parents))
             line_end = line[-1]

--- a/netutils/config/parser.py
+++ b/netutils/config/parser.py
@@ -678,7 +678,7 @@ class F5ConfigParser(BaseBraceConfigParser):
             >>>
             >>>
             >>> config_tree = F5ConfigParser(str(config))
-            >>> pprint(config_tree.build_config_relationship())
+            >>> print(config_tree.build_config_relationship())
             [ConfigLine(config_line='apm resource webtop-link aShare {', parents=()),
             ConfigLine(config_line='    application-uri http://funshare.example.com', parents=('apm resource webtop-link aShare {',)),
             ConfigLine(config_line='    customization-group a_customization_group', parents=('apm resource webtop-link aShare {',)),

--- a/netutils/config/parser.py
+++ b/netutils/config/parser.py
@@ -684,7 +684,7 @@ class F5ConfigParser(BaseBraceConfigParser):
             ConfigLine(config_line='apm sso form-based portal_ext_sso_form_based {', parents=()),
             ConfigLine(config_line='    form-action /Citrix/Example/ExplicitAuth/LoginAttempt', parents=('apm sso form-based portal_ext_sso_form_based {',)),
             ConfigLine(config_line='    form-field "LoginBtn Log+On\nStateContext "', parents=('apm sso form-based portal_ext_sso_form_based {',)),
-            ConfigLine(config_line='    form-password password', parents=()),
+            ConfigLine(config_line='    form***', parents=()),
             ConfigLine(config_line='    form-username username', parents=()),
             ConfigLine(config_line='    passthru true', parents=()),
             ConfigLine(config_line='    start-uri /Citrix/Example/ExplicitAuth/Login*', parents=()),

--- a/netutils/config/parser.py
+++ b/netutils/config/parser.py
@@ -603,10 +603,13 @@ class F5ConfigParser(BaseBraceConfigParser):
         Args:
             config (str): The config text to parse.
         """
-        super(F5ConfigParser, self).__init__(self._clean_config_f5(config))
+        super().__init__(self._clean_config_f5(config))
 
     def _clean_config_f5(self, config_text):  # pylint: disable=no-self-use
-        """Removes all configuration items with 'ltm rule'.  iRules are essentially impossible to parse with the lack of uniformity.
+        """Removes all configuration items with 'ltm rule'.
+        
+        iRules are essentially impossible to parse with the lack of uniformity,
+        therefore, this method ensures they are not included in ``self.config``.
 
         Args:
             config_text (str): The entire config as a string.

--- a/netutils/config/parser.py
+++ b/netutils/config/parser.py
@@ -607,7 +607,7 @@ class F5ConfigParser(BaseBraceConfigParser):
 
     def _clean_config_f5(self, config_text):  # pylint: disable=no-self-use
         """Removes all configuration items with 'ltm rule'.
-        
+
         iRules are essentially impossible to parse with the lack of uniformity,
         therefore, this method ensures they are not included in ``self.config``.
 

--- a/netutils/config/parser.py
+++ b/netutils/config/parser.py
@@ -657,6 +657,13 @@ class F5ConfigParser(BaseBraceConfigParser):
             ConfigLine: The multiline string text that was added to ``self.config_lines``.
 
         Example:
+            config = '''apm resource webtop-link aShare {
+                application-uri http://funshare.example.com
+                customization-group a_customization_group
+            }
+            apm sso form-based portal_ext_sso_form_based {
+                form-action /Citrix/Example/ExplicitAuth/LoginAttempt
+            >>>
             >>> config = '''apm resource webtop-link aShare {
             ...     application-uri http://funshare.example.com
             ...     customization-group a_customization_group
@@ -677,20 +684,7 @@ class F5ConfigParser(BaseBraceConfigParser):
             >>>
             >>> config_tree = F5ConfigParser(str(config))
             >>> print(config_tree.build_config_relationship())
-            [ConfigLine(config_line='apm resource webtop-link aShare {', parents=()),
-            ConfigLine(config_line='    application-uri http://funshare.example.com', parents=('apm resource webtop-link aShare {',)),
-            ConfigLine(config_line='    customization-group a_customization_group', parents=('apm resource webtop-link aShare {',)),
-            ConfigLine(config_line='}', parents=('apm resource webtop-link aShare {',)),
-            ConfigLine(config_line='apm sso form-based portal_ext_sso_form_based {', parents=()),
-            ConfigLine(config_line='    form-action /Citrix/Example/ExplicitAuth/LoginAttempt', parents=('apm sso form-based portal_ext_sso_form_based {',)),
-            ConfigLine(config_line='    form-field "LoginBtn Log+On\nStateContext "', parents=('apm sso form-based portal_ext_sso_form_based {',)),
-            ConfigLine(config_line='    form***', parents=()),
-            ConfigLine(config_line='    form-username username', parents=()),
-            ConfigLine(config_line='    passthru true', parents=()),
-            ConfigLine(config_line='    start-uri /Citrix/Example/ExplicitAuth/Login*', parents=()),
-            ConfigLine(config_line='    success-match-type cookie', parents=()),
-            ConfigLine(config_line='    success-match-value CtxsAuthId', parents=()),
-            ConfigLine(config_line='}', parents=())]
+            [ConfigLine(config_line='apm resource webtop-link aShare {', parents=()), ConfigLine(config_line='    application-uri http://funshare.example.com', parents=('apm resource webtop-link aShare {',)), ConfigLine(config_line='    customization-group a_customization_group', parents=('apm resource webtop-link aShare {',)), ConfigLine(config_line='}', parents=('apm resource webtop-link aShare {',)), ConfigLine(config_line='apm sso form-based portal_ext_sso_form_based {', parents=()), ConfigLine(config_line='    form-action /Citrix/Example/ExplicitAuth/LoginAttempt', parents=('apm sso form-based portal_ext_sso_form_based {',)), ConfigLine(config_line='    form-field "LoginBtn Log+On\nStateContext "', parents=('apm sso form-based portal_ext_sso_form_based {',)), ConfigLine(config_line='    form-password password', parents=()), ConfigLine(config_line='    form-username username', parents=()), ConfigLine(config_line='    passthru true', parents=()), ConfigLine(config_line='    start-uri /Citrix/Example/ExplicitAuth/Login*', parents=()), ConfigLine(config_line='    success-match-type cookie', parents=()), ConfigLine(config_line='    success-match-value CtxsAuthId', parents=()), ConfigLine(config_line='}', parents=())]
         """
         multiline_config = [prev_line]
         for line in self.generator_config:

--- a/netutils/config/parser.py
+++ b/netutils/config/parser.py
@@ -626,7 +626,7 @@ class F5ConfigParser(BaseBraceConfigParser):
 
     def build_config_relationship(self):
         r"""Parse text tree of config lines and their parents.
-        
+
         Example:
             >>> config = '''apm resource webtop-link aShare {
             ...     application-uri http://funshare.example.com
@@ -644,10 +644,10 @@ class F5ConfigParser(BaseBraceConfigParser):
             ...     success-match-value CtxsAuthId
             ... }
             ... '''
-            >>> 
+            >>>
             >>> config_tree = F5ConfigParser(config)
             >>> print(config_tree.build_config_relationship())
-            [ConfigLine(config_line='apm resource webtop-link aShare {', parents=()), ConfigLine(config_line='    application-uri http://funshare.example.com', parents=('apm resource webtop-link aShare {',)), ConfigLine(config_line='    customization-group a_customization_group', parents=('apm resource webtop-link aShare {',)), ConfigLine(config_line='}', parents=('apm resource webtop-link aShare {',)), ConfigLine(config_line='apm sso form-based portal_ext_sso_form_based {', parents=()), ConfigLine(config_line='    form-action /Citrix/Example/ExplicitAuth/LoginAttempt', parents=('apm sso form-based portal_ext_sso_form_based {',)), ConfigLine(config_line='    form-field "LoginBtn Log+On\nStateContext "', parents=('apm sso form-based portal_ext_sso_form_based {',)), ConfigLine(config_line='    form-password password', parents=()), ConfigLine(config_line='    form-username username', parents=()), ConfigLine(config_line='    passthru true', parents=()), ConfigLine(config_line='    start-uri /Citrix/Example/ExplicitAuth/Login*', parents=()), ConfigLine(config_line='    success-match-type cookie', parents=()), ConfigLine(config_line='    success-match-value CtxsAuthId', parents=()), ConfigLine(config_line='}', parents=())]        
+            [ConfigLine(config_line='apm resource webtop-link aShare {', parents=()), ConfigLine(config_line='    application-uri http://funshare.example.com', parents=('apm resource webtop-link aShare {',)), ConfigLine(config_line='    customization-group a_customization_group', parents=('apm resource webtop-link aShare {',)), ConfigLine(config_line='}', parents=('apm resource webtop-link aShare {',)), ConfigLine(config_line='apm sso form-based portal_ext_sso_form_based {', parents=()), ConfigLine(config_line='    form-action /Citrix/Example/ExplicitAuth/LoginAttempt', parents=('apm sso form-based portal_ext_sso_form_based {',)), ConfigLine(config_line='    form-field "LoginBtn Log+On\nStateContext "', parents=('apm sso form-based portal_ext_sso_form_based {',)), ConfigLine(config_line='    form-password password', parents=()), ConfigLine(config_line='    form-username username', parents=()), ConfigLine(config_line='    passthru true', parents=()), ConfigLine(config_line='    start-uri /Citrix/Example/ExplicitAuth/Login*', parents=()), ConfigLine(config_line='    success-match-type cookie', parents=()), ConfigLine(config_line='    success-match-value CtxsAuthId', parents=()), ConfigLine(config_line='}', parents=())]
         """
         for line in self.generator_config:
             self.config_lines.append(ConfigLine(line, self._current_parents))

--- a/netutils/config/parser.py
+++ b/netutils/config/parser.py
@@ -624,6 +624,85 @@ class F5ConfigParser(BaseBraceConfigParser):
             final_config = config_text
         return final_config
 
+    def build_config_relationship(self):
+        r"""Parse text tree of config lines and their parents."""
+        for line in self.generator_config:
+            self.config_lines.append(ConfigLine(line, self._current_parents))
+            line_end = line[-1]
+            if line.endswith("{"):
+                self._current_parents += (line,)
+            elif line.lstrip() == "}":
+                self._current_parents = self._current_parents[:-1]
+            elif any(
+                delimiters in self.multiline_delimiters and line.count(delimiters) == 1
+                for delimiters in self.multiline_delimiters
+            ):
+                for delimiter in self.multiline_delimiters:
+                    if line.count(delimiter) == 1:
+                        self._build_multiline_single_configuration_line(delimiter, line)
+            elif line_end in self.multiline_delimiters and line.count(line_end) == 1:
+                self._current_parents += (line,)
+                self._build_multiline_config(line_end)
+
+        return self.config_lines
+
+    def _build_multiline_single_configuration_line(self, delimiter, prev_line):
+        r"""Concatenate Multiline strings between delimiter when newlines causes string to traverse multiple lines.
+
+        Args:
+            delimiter (str): The text to look for to end multiline config.
+            prev_line (str): The text from the previously analyzed line.
+
+        Returns:
+            ConfigLine: The multiline string text that was added to ``self.config_lines``.
+
+        Example:
+            config = '''apm resource webtop-link aShare {
+                application-uri http://>>>
+            >>> config = '''apm resource webtop-link aShare {
+            ...     application-uri http://funshare.example.com
+            ...     customization-group a_customization_group
+            ... }
+            ... apm sso form-based portal_ext_sso_form_based {
+            ...     form-action /Citrix/Example/ExplicitAuth/LoginAttempt
+            ...     form-field "LoginBtn Log+On
+            ... StateContext "
+            ...     form-password password
+            ...     form-username username
+            ...     passthru true
+            ...     start-uri /Citrix/Example/ExplicitAuth/Login*
+            ...     success-match-type cookie
+            ...     success-match-value CtxsAuthId
+            ... }
+            ... '''
+            >>>
+            >>>
+            >>> config_tree = F5ConfigParser(str(config))
+            >>> pprint(config_tree.build_config_relationship())
+            [ConfigLine(config_line='apm resource webtop-link aShare {', parents=()),
+            ConfigLine(config_line='    application-uri http://funshare.example.com', parents=('apm resource webtop-link aShare {',)),
+            ConfigLine(config_line='    customization-group a_customization_group', parents=('apm resource webtop-link aShare {',)),
+            ConfigLine(config_line='}', parents=('apm resource webtop-link aShare {',)),
+            ConfigLine(config_line='apm sso form-based portal_ext_sso_form_based {', parents=()),
+            ConfigLine(config_line='    form-action /Citrix/Example/ExplicitAuth/LoginAttempt', parents=('apm sso form-based portal_ext_sso_form_based {',)),
+            ConfigLine(config_line='    form-field "LoginBtn Log+On\nStateContext "', parents=('apm sso form-based portal_ext_sso_form_based {',)),
+            ConfigLine(config_line='    form-password password', parents=()),
+            ConfigLine(config_line='    form-username username', parents=()),
+            ConfigLine(config_line='    passthru true', parents=()),
+            ConfigLine(config_line='    start-uri /Citrix/Example/ExplicitAuth/Login*', parents=()),
+            ConfigLine(config_line='    success-match-type cookie', parents=()),
+            ConfigLine(config_line='    success-match-value CtxsAuthId', parents=()),
+            ConfigLine(config_line='}', parents=())]
+        """
+        multiline_config = [prev_line]
+        for line in self.generator_config:
+            multiline_config.append(line)
+            if line.endswith(delimiter):
+                multiline_entry = ConfigLine("\n".join(multiline_config), self._current_parents)
+                self.config_lines[-1] = multiline_entry
+                self._current_parents = self._current_parents[:-1]
+                return multiline_entry
+
 
 class JunosConfigParser(BaseSpaceConfigParser):
     """Junos config parser."""

--- a/netutils/config/parser.py
+++ b/netutils/config/parser.py
@@ -657,8 +657,6 @@ class F5ConfigParser(BaseBraceConfigParser):
             ConfigLine: The multiline string text that was added to ``self.config_lines``.
 
         Example:
-            config = '''apm resource webtop-link aShare {
-                application-uri http://>>>
             >>> config = '''apm resource webtop-link aShare {
             ...     application-uri http://funshare.example.com
             ...     customization-group a_customization_group

--- a/netutils/config/parser.py
+++ b/netutils/config/parser.py
@@ -597,6 +597,33 @@ class F5ConfigParser(BaseBraceConfigParser):
 
     multiline_delimiters = ['"']
 
+    def __init__(self, config):
+        """Create ConfigParser Object.
+
+        Args:
+            config (str): The config text to parse.
+        """
+        super(F5ConfigParser, self).__init__(self._clean_config_f5(config))
+
+    def _clean_config_f5(self, config_text):  # pylint: disable=no-self-use
+        """Removes all configuration items with 'ltm rule'.  iRules are essentially impossible to parse with the lack of uniformity.
+
+        Args:
+            config_text (str): The entire config as a string.
+
+        Returns:
+            str: The sanitized config with all iRules (ltm rule) stanzas removed.
+        """
+        config_split = config_text.split("ltm rule")
+        if len(config_split) > 1:
+            start_config = config_split[0]
+            end_config = config_split[-1]
+            _, ltm, clean_config = end_config.partition("ltm")
+            final_config = start_config + ltm + clean_config
+        else:
+            final_config = config_text
+        return final_config
+
 
 class JunosConfigParser(BaseSpaceConfigParser):
     """Junos config parser."""

--- a/tests/unit/mock/config/parser/bigip_f5/bigip_full_received.py
+++ b/tests/unit/mock/config/parser/bigip_f5/bigip_full_received.py
@@ -24,6 +24,30 @@ data = [
     ConfigLine(config_line="    }", parents=("auth user admin {", "    partition-access {")),
     ConfigLine(config_line="    shell bash", parents=("auth user admin {",)),
     ConfigLine(config_line="}", parents=("auth user admin {",)),
+    ConfigLine(config_line="apm resource webtop-link aShare {", parents=()),
+    ConfigLine(
+        config_line="    application-uri http://funshare.example.com", parents=("apm resource webtop-link aShare {",)
+    ),
+    ConfigLine(
+        config_line="    customization-group a_customization_group", parents=("apm resource webtop-link aShare {",)
+    ),
+    ConfigLine(config_line="}", parents=("apm resource webtop-link aShare {",)),
+    ConfigLine(config_line="apm sso form-based portal_ext_sso_form_based {", parents=()),
+    ConfigLine(
+        config_line="    form-action /Citrix/Example/ExplicitAuth/LoginAttempt",
+        parents=("apm sso form-based portal_ext_sso_form_based {",),
+    ),
+    ConfigLine(
+        config_line='    form-field "LoginBtn Log+On\nStateContext "',
+        parents=("apm sso form-based portal_ext_sso_form_based {",),
+    ),
+    ConfigLine(config_line="    form-password password", parents=()),
+    ConfigLine(config_line="    form-username username", parents=()),
+    ConfigLine(config_line="    passthru true", parents=()),
+    ConfigLine(config_line="    start-uri /Citrix/Example/ExplicitAuth/Login*", parents=()),
+    ConfigLine(config_line="    success-match-type cookie", parents=()),
+    ConfigLine(config_line="    success-match-value CtxsAuthId", parents=()),
+    ConfigLine(config_line="}", parents=()),
     ConfigLine(config_line="cli global-settings { }", parents=()),
     ConfigLine(config_line="cli preference {", parents=()),
     ConfigLine(config_line="    alias-path { /Common }", parents=("cli preference {",)),

--- a/tests/unit/mock/config/parser/bigip_f5/bigip_full_sent.txt
+++ b/tests/unit/mock/config/parser/bigip_f5/bigip_full_sent.txt
@@ -13,6 +13,21 @@ auth user admin {
     }
     shell bash
 }
+apm resource webtop-link aShare {
+    application-uri http://funshare.example.com
+    customization-group a_customization_group
+}
+apm sso form-based portal_ext_sso_form_based {
+    form-action /Citrix/Example/ExplicitAuth/LoginAttempt
+    form-field "LoginBtn Log+On
+StateContext "
+    form-password password
+    form-username username
+    passthru true
+    start-uri /Citrix/Example/ExplicitAuth/Login*
+    success-match-type cookie
+    success-match-value CtxsAuthId
+}
 cli global-settings { }
 cli preference {
     alias-path { /Common }

--- a/tests/unit/mock/config/parser/bigip_f5/bigip_full_sent.txt
+++ b/tests/unit/mock/config/parser/bigip_f5/bigip_full_sent.txt
@@ -154,6 +154,40 @@ ltm global-settings general {
     share-single-mac vmw-compat
 }
 ltm global-settings rule { }
+ltm rule imap_tls {
+when CLIENT_ACCEPTED {   
+     SSL::disable 
+ }   
+ when SERVER_CONNECTED {   
+     TCP::collect 
+ }   
+ when CLIENT_DATA {   
+     set lcpayload [string tolower [TCP::payload]] 
+     if { $lcpayload contains "starttls" } {  
+         set tag [getfield [TCP::payload]  " " 1] 
+         TCP::respond "$tag OK \"Begin TLS negotiation now\"\r\n" 
+         TCP::payload replace 0 [TCP::payload length] "" 
+         TCP::release 
+         SSL::enable 
+     } else { 
+         set id [getfield [TCP::payload]  " " 1] 
+         TCP::respond "$id BAD \"Must issue a STARTTLS command first\"\r\n" 
+         TCP::payload replace 0 [TCP::payload length] "" 
+         TCP::release 
+         TCP::collect 
+     }   
+ }   
+ when SERVER_DATA { 
+     if { [TCP::payload] contains "* CAPABILITY" } { 
+         TCP::payload replace 12 0 " STARTTLS" 
+         TCP::release 
+         clientside { TCP::collect }   
+     } else { 
+         TCP::release 
+         TCP::collect 
+     } 
+}
+}
 ltm global-settings traffic-control { }
 ltm persistence global-settings { }
 ltm tacdb licenseddb licensed-tacdb {


### PR DESCRIPTION
Add a preprocessing step that sanitizes the F5 configs completely removing the `ltm rule` configuration sections.  These sections are not uniform or standardized which makes a regex find or other solution very challenging.  ltm rule compliance checking is probably not frequently needed.