### PR TITLE
Prefix aggregate and gap finder

### DIFF
--- a/netutils/route.py
+++ b/netutils/route.py
@@ -1,5 +1,6 @@
 """Utilities to get best route from routing table."""
 
+from typing import Union, List, Set, Dict
 import ipaddress
 
 
@@ -43,3 +44,151 @@ def longest_prefix_match(ip_addr, routes):
         return str(sorted(networks)[-1])
     except IndexError as error:
         raise NoRouteFound("No Matching Route Found.") from error
+
+
+IPNetwork = Union[ipaddress.IPv4Network, ipaddress.IPv6Network]
+
+
+def prefix_aggregate(
+    prefixes: List[Union[ipaddress.IPv4Network, ipaddress.IPv6Network, str]],
+    force_continuous: bool = True,
+    min_aggr_pref_len: int = 0,
+) -> Set[Union[ipaddress.IPv4Network, ipaddress.IPv6Network]]:
+    """Aggregate prefixes based on set minimum length and continuity
+
+    Args:
+        prefixes (str): list of prefixes as string or ``ipaddress`` network object
+        force_continuous (boot): If ``True``, only consider continuous address range and don't make "holes" in the result
+        min_aggr_pref_len (int): output should contain this big prefixes only
+
+    Returns:
+        Set of IPv4 or IPv6 Network objects which are aggregates for the input
+
+    Example:
+        >>> prefix_aggregate(["10.0.0.0/24", "10.0.1.0/24"])
+        {IPv4Network('10.0.0.0/23')}
+
+        >>> prefix_aggregate(["10.0.0.0/24", "10.0.2.0/24"])
+        {IPv4Network('10.0.0.0/24'), IPv4Network('10.0.2.0/24')}
+
+        >>> prefix_aggregate(["10.0.0.0/24", "10.0.2.0/24"], force_continuous=False)
+        {IPv4Network('10.0.0.0/22')}
+
+        >>> prefix_aggregate(["10.0.0.0/24", "10.0.2.0/24", "10.0.3.0/24"], force_continuous=False, min_aggr_pref_len=23)
+        {IPv4Network('10.0.0.0/24'), IPv4Network('10.0.2.0/23')}
+    """
+    aggregates = set()
+    # validate input
+    if not prefixes:
+        return aggregates
+    # check address family
+    try:
+        # assume ipv4
+        family = type(ipaddress.IPv4Network(prefixes[0]))
+    except (ipaddress.AddressValueError, ipaddress.NetmaskValueError):
+        # try to use ipv6
+        try:
+            family = type(ipaddress.IPv6Network(prefixes[0]))
+        except (ipaddress.AddressValueError, ipaddress.NetmaskValueError, ValueError) as err:
+            raise ipaddress.AddressValueError("Please specify valid IPv4 or IPv6 networks!") from err
+    if min_aggr_pref_len > family(0).max_prefixlen:
+        raise ipaddress.AddressValueError(f"min_aggr_pref_len is bigger than expected ({family.max_prefixlen})")
+    # convert all input elements to ipaddress object
+    prefixes = {family(prefix) for prefix in prefixes}
+    prefixes = list(ipaddress.collapse_addresses(prefixes))
+
+    # split prefixes where prefix length is too small
+    while prefixes:
+        aggregate = prefixes.pop(0)
+        if aggregate.prefixlen < min_aggr_pref_len:
+            aggregates.update(aggregate.subnets(prefixlen_diff=min_aggr_pref_len - aggregate.prefixlen))
+        else:
+            aggregates.add(aggregate)
+    if force_continuous:
+        return aggregates
+
+    prefixes = list(aggregates)
+    prefixes.sort()
+    aggregates = set()
+
+    min_aggregate = None
+    while prefixes:
+        aggregate: IPNetwork = prefixes.pop(0)
+        eliminated = False
+        while prefixes:
+            if aggregate.prefixlen < min_aggr_pref_len:  # don't eliminate if we crossed the limit
+                break
+            if prefixes[0].subnet_of(aggregate):
+                prefixes.pop(0)  # eliminate contained prefix
+                eliminated = True
+            else:  # skip checking the following elements as those are guaranteed not contained
+                break
+        if eliminated:
+            min_aggregate = aggregate
+        if aggregate.prefixlen > min_aggr_pref_len and prefixes:
+            prefixes.insert(0, aggregate.supernet())
+            if not min_aggregate:
+                min_aggregate = aggregate
+        else:
+            aggregates.add(min_aggregate or aggregate)
+            min_aggregate = None
+
+    return aggregates
+
+
+def find_prefix_gaps(
+    prefixes: List[Union[ipaddress.IPv4Network, ipaddress.IPv6Network, str]], min_gap_size: int, scope: int = 0
+) -> Dict[IPNetwork, List[IPNetwork]]:
+    """Find gaps in given prefix list
+
+    By default this function will find the longer possible aggregate prefix for the input. Then looks for gaps in
+    that aggregate.
+    The ``scope`` parameter can influence how long aggregates do we want to check at minimum.
+    To limit how small gaps would be returned, set ``min_gap_size`` to a minimum prefix length.
+
+    Args:
+        prefixes: list of prefixes to be checked
+        min_gap_size: filter out longer prefixes than that
+        scope: determine the minimum prefix length
+
+    Returns:
+        list of IPvXNetwork objects which represents gaps in the given range
+
+    Example:
+        >>> find_prefix_gaps(["10.0.0.0/30", "10.0.0.12/30"], min_gap_size=30)
+        {IPv4Network('10.0.0.0/28'): [IPv4Network('10.0.0.4/30'), IPv4Network('10.0.0.8/30')]}
+
+        >>> find_prefix_gaps(["10.0.0.1", "10.0.0.1", "10.0.0.1", "10.0.0.8/29"], min_gap_size=30)
+        {IPv4Network('10.0.0.0/28'): [IPv4Network('10.0.0.4/30')]}
+
+        Without the scope, we would get a /21 aggregate with more gaps. With scope, we want /22 aggregates
+        10.0.4.0/24 is not part of the 10.0.0.0/22 and as being a /24 itself has no gaps.
+
+        >>> find_prefix_gaps(["10.0.0.0/24", "10.0.2.0/24", "10.0.3.0/24", "10.0.4.0/24"], min_gap_size=24, scope=22)
+        {IPv4Network('10.0.0.0/22'): [IPv4Network('10.0.1.0/24')]}
+    """
+    gaps = {}
+    assert 0 <= min_gap_size <= 128
+    assert 0 <= scope <= 128
+
+    supernets = prefix_aggregate(prefixes, min_aggr_pref_len=scope, force_continuous=False)
+    continuous_prefs = prefix_aggregate(prefixes, min_aggr_pref_len=scope, force_continuous=True)
+
+    if min_gap_size < 0:
+        # a safe value else we can easily generate millions of missing IPs
+        min_gap_size = list(supernets)[0].max_prefixlen - 3
+
+    for supernet in supernets:
+        cps = {prefix for prefix in continuous_prefs if prefix.subnet_of(supernet)}
+        max_prefix_len = max([prefix.prefixlen for prefix in cps])
+        agg_split = prefix_aggregate([supernet], min_aggr_pref_len=max_prefix_len)
+        pref_pool = set()
+        for prefix in cps:
+            pref_pool.update(prefix_aggregate([prefix], min_aggr_pref_len=max_prefix_len))
+        gap_list = [
+            prefix for prefix in ipaddress.collapse_addresses(agg_split - pref_pool) if prefix.prefixlen <= min_gap_size
+        ]
+        gap_list.sort()
+        if gap_list:
+            gaps[supernet] = gap_list
+    return gaps

--- a/tests/unit/test_route.py
+++ b/tests/unit/test_route.py
@@ -137,8 +137,9 @@ def test_prefix_aggregate_bad_minimum_preflength():
     prefixes = [
         "10.0.0.0/24"
     ]
-    with pytest.raises(AddressValueError):
+    with pytest.raises(AssertionError) as execinfo:
         prefix_aggregate(prefixes, min_aggr_pref_len=33)
+    assert execinfo.match("^min_aggr_pref_len is bigger than expected")
 
 
 def test_prefix_aggregate_too_big_min_prefix_length():
@@ -246,7 +247,9 @@ def test_find_gaps_with_gap():
         # IPv4Network("10.0.0.128/25"),  # gap
         IPv4Network("10.0.1.0/24"),
     ]
-    assert find_prefix_gaps(prefixes=prefixes, min_gap_size=25) == {IPv4Network("10.0.0.0/23"): [IPv4Network("10.0.0.128/25")]}
+    assert find_prefix_gaps(prefixes=prefixes, min_gap_size=25) == {
+        IPv4Network("10.0.0.0/23"): [IPv4Network("10.0.0.128/25")]
+    }
 
 
 def test_find_gaps_ipv6():
@@ -254,8 +257,12 @@ def test_find_gaps_ipv6():
         "2001:db8:0:1::/64",
         "2001:db8:0:2::/64"
     ]
-    assert find_prefix_gaps(prefixes, min_gap_size=80) == {IPv6Network('2001:db8::/62'): [IPv6Network('2001:db8::/64'),
-                                                                                          IPv6Network('2001:db8:0:3::/64')]}
+    assert find_prefix_gaps(prefixes, min_gap_size=80) == {
+        IPv6Network('2001:db8::/62'): [
+            IPv6Network('2001:db8::/64'),
+            IPv6Network('2001:db8:0:3::/64')
+        ]
+    }
 
 
 def test_find_gaps_with_no_gap():


### PR DESCRIPTION
Dear NTC,

these functions brings ability to find certain sized aggregates amongst provided prefixes and also we can find gaps in these aggregates. Can be useful by routing protocol aggregate development and free subnet finding on a given site.