### PR TITLE
remove support for old function 'is_fqdn_valid' as prep for 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v1.0.0 - 2021-11
+
+### Added
+
+- #69 Normalise banner demiliter for IOS to ^C & support parsing delimiter ^
+
+### Fixed
+
+- #79 F5 parser fix for irules with multiline single command lines.
+
+### Removed
+
+- #83 remove support for old function 'is_fqdn_valid' as prep for 1.0.0
+
 ## v0.2.5 - 2021-11
 
 ### Added

--- a/netutils/__init__.py
+++ b/netutils/__init__.py
@@ -1,3 +1,3 @@
 """Initialization file for library."""
 
-__version__ = "0.2.5"
+__version__ = "1.0.0"

--- a/netutils/dns.py
+++ b/netutils/dns.py
@@ -53,7 +53,3 @@ def is_fqdn_resolvable(hostname):
         return True
     except socket.error:
         return False
-
-
-# Provide until transition to 1.0
-is_fqdn_valid = is_fqdn_resolvable

--- a/netutils/utils.py
+++ b/netutils/utils.py
@@ -17,7 +17,6 @@ _JINJA2_FUNCTION_MAPPINGS = {
     "find_unordered_cfg_lines": "config.compliance.find_unordered_cfg_lines",
     "section_config": "config.compliance.section_config",
     "fqdn_to_ip": "dns.fqdn_to_ip",
-    "is_fqdn_valid": "dns.is_fqdn_valid",
     "is_fqdn_resolvable": "dns.is_fqdn_resolvable",
     "interface_range_expansion": "interface.interface_range_expansion",
     "interface_range_compress": "interface.interface_range_compress",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "netutils"
-version = "0.2.5"
+version = "1.0.0"
 description = "Common helper functions useful in network automation."
 authors = ["Network to Code, LLC <opensource@networktocode.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
# Provide until transition to 1.0
is_fqdn_valid = is_fqdn_resolvable

Removing is_fqdn_valid callable. To prep for 1.0.0 release.