### PR TITLE
Add normalize delimiter methods to NXOS

### DIFF
--- a/netutils/config/parser.py
+++ b/netutils/config/parser.py
@@ -3,6 +3,7 @@
 
 import re
 from collections import namedtuple
+
 from netutils.banner import normalise_delimiter_caret_c
 
 ConfigLine = namedtuple("ConfigLine", "config_line,parents")
@@ -570,6 +571,32 @@ class NXOSConfigParser(CiscoConfigParser, BaseSpaceConfigParser):
     """NXOS implementation of ConfigParser Class."""
 
     regex_banner = re.compile(r"^banner\s+\S+\s+(?P<banner_delimiter>\S)")
+
+    def __init__(self, config):
+        """Create ConfigParser Object.
+
+        Args:
+            config (str): The config text to parse.
+        """
+        self.unique_config_lines = set()
+        self.same_line_children = set()
+        super(NXOSConfigParser, self).__init__(config)
+
+    def _build_banner(self, config_line):
+        """Handle banner config lines.
+
+        Args:
+            config_line (str): The start of the banner config.
+
+        Returns:
+            str: The next configuration line in the configuration text.
+            None: When banner end is the end of the config text.
+
+        Raises:
+            ValueError: When the parser is unable to identify the End of the Banner.
+        """
+        config_line = normalise_delimiter_caret_c(self.banner_end, config_line)
+        return super(NXOSConfigParser, self)._build_banner(config_line)
 
 
 class EOSConfigParser(BaseSpaceConfigParser):

--- a/tests/unit/mock/config/compliance/compliance/cisco_nxos/nxos_basic_backup.txt
+++ b/tests/unit/mock/config/compliance/compliance/cisco_nxos/nxos_basic_backup.txt
@@ -98,6 +98,11 @@ logging level smm 4
 logging level u6rib 4
 logging level lldp 4
 
+banner motd #
+This is a test,
+banner message.
+#
+
 no password strength-check
 username admin password 5 <redacted_config>  role network-admin
 username ntc password 5 <redacted_config>  role network-admin

--- a/tests/unit/mock/config/compliance/compliance/cisco_nxos/nxos_basic_feature.py
+++ b/tests/unit/mock/config/compliance/compliance/cisco_nxos/nxos_basic_feature.py
@@ -1,3 +1,4 @@
 features = [
     {"name": "bgp", "ordered": True, "section": ["router bgp "]},
+    {"name": "banner", "ordered": True, "section": ["banner "]},
 ]

--- a/tests/unit/mock/config/compliance/compliance/cisco_nxos/nxos_basic_intended.txt
+++ b/tests/unit/mock/config/compliance/compliance/cisco_nxos/nxos_basic_intended.txt
@@ -97,7 +97,12 @@ logging level rpm 4
 logging level smm 4
 logging level u6rib 4
 logging level lldp 4
-
+!
+banner motd #
+This is a test,
+banner message.
+#
+!
 no password strength-check
 username admin password 5 <redacted_config>  role network-admin
 username ntc password 5 <redacted_config>  role network-admin

--- a/tests/unit/mock/config/compliance/compliance/cisco_nxos/nxos_basic_received.json
+++ b/tests/unit/mock/config/compliance/compliance/cisco_nxos/nxos_basic_received.json
@@ -8,5 +8,15 @@
       "missing": "",
       "ordered_compliant": true,
       "unordered_compliant": true
-   }
+   },
+   "banner": {
+      "actual": "banner motd ^C\nThis is a test,\nbanner message.^C",
+      "cannot_parse": true,
+      "compliant": true,
+      "extra": "",
+      "intended": "banner motd ^C\nThis is a test,\nbanner message.^C",
+      "missing": "",
+      "ordered_compliant": true,
+      "unordered_compliant": true
+   }   
 }

--- a/tests/unit/mock/config/parser/cisco_nxos/nxos_full_received.py
+++ b/tests/unit/mock/config/parser/cisco_nxos/nxos_full_received.py
@@ -20,6 +20,8 @@ data = [
     ConfigLine(config_line="feature hsrp", parents=()),
     ConfigLine(config_line="feature vpc", parents=()),
     ConfigLine(config_line="feature lldp", parents=()),
+    ConfigLine(config_line="banner motd ^C", parents=()),
+    ConfigLine(config_line="This is a test,\nbanner message.^C", parents=("banner motd ^C",)),
     ConfigLine(config_line="logging level aaa 4", parents=()),
     ConfigLine(config_line="logging level acllog 4", parents=()),
     ConfigLine(config_line="logging level aclmgr 4", parents=()),

--- a/tests/unit/mock/config/parser/cisco_nxos/nxos_full_sent.txt
+++ b/tests/unit/mock/config/parser/cisco_nxos/nxos_full_sent.txt
@@ -19,6 +19,11 @@ feature hsrp
 feature vpc
 feature lldp
 
+banner motd #
+This is a test,
+banner message.
+#
+
 logging level aaa 4
 logging level acllog 4
 logging level aclmgr 4


### PR DESCRIPTION
fixes #93