### PR TITLE
Nokia SrOS Parser

### DIFF
--- a/docs/source/netutils/configs/index.rst
+++ b/docs/source/netutils/configs/index.rst
@@ -14,10 +14,15 @@ Configs
 Edge Cases
 ==============
 
-Fortinet Fortios Parser
+Fortinet FortiOS Parser
 -----------------------
-- In order to support html blocks that exist in Fortios configurations, some preprocessing is executed, this is a regex that specifically grabs everything between quotes after the 'set buffer' sub-command. It's explicitly looking for double quote followed by a newline ("\n) to end the captured data.  This support for html data will not support any other html that doesn't follow this convention.
+- To support HTML blocks that exist in FortiOS configurations, some preprocessing via a regex is performed that specifically grabs everything between quotes after the 'set buffer' sub-command. It is explicitly looking for the double quote followed by a newline ("\n) to end the captured data. This support for HTML data will not support any other HTML that doesn't follow this convention.
 
 F5 Parser
 -----------------------
-- The "ltm rule" configuration sections are not uniform nor standardized; therefor, these sections are completely removed from the configuration in a preprocessing event.
+- The "ltm rule" configuration sections are not uniform nor standardized; therefore, these sections are completely removed from the configuration in a preprocessing event.
+
+Nokia SrOS Parser
+-----------------
+
+- The parser depends upon the configuration presented in backups being in the "info" format as opposed to the indented MD-CLI format.

--- a/netutils/config/compliance.py
+++ b/netutils/config/compliance.py
@@ -12,6 +12,7 @@ parser_map = {
     "juniper_junos": parser.JunosConfigParser,
     "cisco_asa": parser.ASAConfigParser,
     "fortinet_fortios": parser.FortinetConfigParser,
+    "nokia_sros": parser.NokiaConfigParser,
 }
 
 default_feature = {

--- a/netutils/config/parser.py
+++ b/netutils/config/parser.py
@@ -1,5 +1,5 @@
 """Parsers for different network operating systems."""
-# pylint: disable=no-member,super-with-arguments,invalid-overridden-method,raise-missing-from,invalid-overridden-method,inconsistent-return-statements,super-with-arguments,redefined-argument-from-local,no-else-break,useless-super-delegation
+# pylint: disable=no-member,super-with-arguments,invalid-overridden-method,raise-missing-from,invalid-overridden-method,inconsistent-return-statements,super-with-arguments,redefined-argument-from-local,no-else-break,useless-super-delegation,too-many-lines
 
 import re
 from collections import namedtuple
@@ -949,3 +949,10 @@ class FortinetConfigParser(BaseSpaceConfigParser):
                 self.indent_level = spaces
 
             self._update_config_lines(line)
+
+
+class NokiaConfigParser(BaseSpaceConfigParser):
+    """Nokia SrOS config parser."""
+
+    comment_chars = []
+    banner_start = []

--- a/tests/unit/mock/config/parser/nokia_sros/sros_full_received.py
+++ b/tests/unit/mock/config/parser/nokia_sros/sros_full_received.py
@@ -1,0 +1,529 @@
+from netutils.config.parser import ConfigLine
+
+data = [
+    ConfigLine(config_line="configure { }", parents=()),
+    ConfigLine(config_line="configure { card 1 }", parents=()),
+    ConfigLine(config_line="configure { card 1 card-type iom-1 }", parents=()),
+    ConfigLine(config_line="configure { card 1 mda 1 }", parents=()),
+    ConfigLine(config_line="configure { card 1 mda 1 mda-type me12-100gb-qsfp28 }", parents=()),
+    ConfigLine(config_line="configure { card 1 mda 2 }", parents=()),
+    ConfigLine(config_line="configure { card 1 fp 1 }", parents=()),
+    ConfigLine(config_line="configure { log }", parents=()),
+    ConfigLine(config_line='configure { log filter "1001" }', parents=()),
+    ConfigLine(config_line='configure { log filter "1001" named-entry "10" }', parents=()),
+    ConfigLine(
+        config_line='configure { log filter "1001" named-entry "10" description "Collect only events of major severity or higher" }',
+        parents=(),
+    ),
+    ConfigLine(config_line='configure { log filter "1001" named-entry "10" action forward }', parents=()),
+    ConfigLine(config_line='configure { log filter "1001" named-entry "10" match }', parents=()),
+    ConfigLine(config_line='configure { log filter "1001" named-entry "10" match severity }', parents=()),
+    ConfigLine(config_line='configure { log filter "1001" named-entry "10" match severity gte major }', parents=()),
+    ConfigLine(config_line='configure { log log-id "100" }', parents=()),
+    ConfigLine(config_line='configure { log log-id "100" description "Default Serious Errors Log" }', parents=()),
+    ConfigLine(config_line='configure { log log-id "100" filter "1001" }', parents=()),
+    ConfigLine(config_line='configure { log log-id "100" source }', parents=()),
+    ConfigLine(config_line='configure { log log-id "100" source main true }', parents=()),
+    ConfigLine(config_line='configure { log log-id "100" destination }', parents=()),
+    ConfigLine(config_line='configure { log log-id "100" destination memory }', parents=()),
+    ConfigLine(config_line='configure { log log-id "100" destination memory max-entries 500 }', parents=()),
+    ConfigLine(config_line='configure { log log-id "99" }', parents=()),
+    ConfigLine(config_line='configure { log log-id "99" description "Default System Log" }', parents=()),
+    ConfigLine(config_line='configure { log log-id "99" source }', parents=()),
+    ConfigLine(config_line='configure { log log-id "99" source main true }', parents=()),
+    ConfigLine(config_line='configure { log log-id "99" destination }', parents=()),
+    ConfigLine(config_line='configure { log log-id "99" destination memory }', parents=()),
+    ConfigLine(config_line='configure { log log-id "99" destination memory max-entries 500 }', parents=()),
+    ConfigLine(config_line="configure { port 1/1/c1 }", parents=()),
+    ConfigLine(config_line="configure { port 1/1/c2 }", parents=()),
+    ConfigLine(config_line="configure { port 1/1/c3 }", parents=()),
+    ConfigLine(config_line="configure { port 1/1/c4 }", parents=()),
+    ConfigLine(config_line="configure { port 1/1/c5 }", parents=()),
+    ConfigLine(config_line="configure { port 1/1/c6 }", parents=()),
+    ConfigLine(config_line="configure { port 1/1/c7 }", parents=()),
+    ConfigLine(config_line="configure { port 1/1/c8 }", parents=()),
+    ConfigLine(config_line="configure { port 1/1/c9 }", parents=()),
+    ConfigLine(config_line="configure { port 1/1/c10 }", parents=()),
+    ConfigLine(config_line="configure { port 1/1/c11 }", parents=()),
+    ConfigLine(config_line="configure { port 1/1/c12 }", parents=()),
+    ConfigLine(config_line='configure { router "Base" }', parents=()),
+    ConfigLine(config_line='configure { router "Base" interface "L3-OAM-eNodeB069420-W1" }', parents=()),
+    ConfigLine(
+        config_line='configure { router "Base" interface "L3-OAM-eNodeB069420-W1" admin-state disable }', parents=()
+    ),
+    ConfigLine(
+        config_line='configure { router "Base" interface "L3-OAM-eNodeB069420-W1" ingress-stats false }', parents=()
+    ),
+    ConfigLine(config_line="configure { system }", parents=()),
+    ConfigLine(config_line='configure { system name "core-router" }', parents=()),
+    ConfigLine(config_line="configure { system grpc }", parents=()),
+    ConfigLine(config_line="configure { system grpc admin-state enable }", parents=()),
+    ConfigLine(config_line="configure { system grpc allow-unsecure-connection }", parents=()),
+    ConfigLine(config_line="configure { system grpc gnmi }", parents=()),
+    ConfigLine(config_line="configure { system grpc gnmi auto-config-save true }", parents=()),
+    ConfigLine(config_line="configure { system grpc rib-api }", parents=()),
+    ConfigLine(config_line="configure { system grpc rib-api admin-state enable }", parents=()),
+    ConfigLine(config_line="configure { system management-interface }", parents=()),
+    ConfigLine(config_line="configure { system management-interface configuration-mode model-driven }", parents=()),
+    ConfigLine(config_line="configure { system management-interface netconf }", parents=()),
+    ConfigLine(config_line="configure { system management-interface netconf admin-state enable }", parents=()),
+    ConfigLine(config_line="configure { system management-interface netconf auto-config-save true }", parents=()),
+    ConfigLine(config_line="configure { system management-interface snmp }", parents=()),
+    ConfigLine(config_line="configure { system management-interface snmp packet-size 9216 }", parents=()),
+    ConfigLine(config_line="configure { system management-interface snmp streaming }", parents=()),
+    ConfigLine(config_line="configure { system management-interface snmp streaming admin-state enable }", parents=()),
+    ConfigLine(config_line="configure { system bluetooth }", parents=()),
+    ConfigLine(config_line="configure { system bluetooth advertising-timeout 30 }", parents=()),
+    ConfigLine(config_line="configure { system login-control }", parents=()),
+    ConfigLine(config_line="configure { system login-control ssh }", parents=()),
+    ConfigLine(config_line="configure { system login-control ssh inbound-max-sessions 30 }", parents=()),
+    ConfigLine(config_line="configure { system security }", parents=()),
+    ConfigLine(config_line="configure { system security aaa }", parents=()),
+    ConfigLine(config_line="configure { system security aaa local-profiles }", parents=()),
+    ConfigLine(config_line='configure { system security aaa local-profiles profile "administrative" }', parents=()),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "administrative" default-action permit-all }',
+        parents=(),
+    ),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "administrative" netconf }', parents=()
+    ),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "administrative" netconf base-op-authorization }',
+        parents=(),
+    ),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "administrative" netconf base-op-authorization kill-session true }',
+        parents=(),
+    ),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "administrative" netconf base-op-authorization lock true }',
+        parents=(),
+    ),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "administrative" entry 10 }', parents=()
+    ),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "administrative" entry 10 action permit }',
+        parents=(),
+    ),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "administrative" entry 10 match "configure system security" }',
+        parents=(),
+    ),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "administrative" entry 20 }', parents=()
+    ),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "administrative" entry 20 action permit }',
+        parents=(),
+    ),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "administrative" entry 20 match "show system security" }',
+        parents=(),
+    ),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "administrative" entry 30 }', parents=()
+    ),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "administrative" entry 30 action permit }',
+        parents=(),
+    ),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "administrative" entry 30 match "tools perform security" }',
+        parents=(),
+    ),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "administrative" entry 40 }', parents=()
+    ),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "administrative" entry 40 action permit }',
+        parents=(),
+    ),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "administrative" entry 40 match "tools dump security" }',
+        parents=(),
+    ),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "administrative" entry 50 }', parents=()
+    ),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "administrative" entry 50 action permit }',
+        parents=(),
+    ),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "administrative" entry 50 match "admin system security" }',
+        parents=(),
+    ),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "administrative" entry 100 }', parents=()
+    ),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "administrative" entry 100 action deny }',
+        parents=(),
+    ),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "administrative" entry 100 match "configure li" }',
+        parents=(),
+    ),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "administrative" entry 110 }', parents=()
+    ),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "administrative" entry 110 action deny }',
+        parents=(),
+    ),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "administrative" entry 110 match "show li" }',
+        parents=(),
+    ),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "administrative" entry 111 }', parents=()
+    ),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "administrative" entry 111 action deny }',
+        parents=(),
+    ),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "administrative" entry 111 match "clear li" }',
+        parents=(),
+    ),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "administrative" entry 112 }', parents=()
+    ),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "administrative" entry 112 action deny }',
+        parents=(),
+    ),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "administrative" entry 112 match "tools dump li" }',
+        parents=(),
+    ),
+    ConfigLine(config_line='configure { system security aaa local-profiles profile "default" }', parents=()),
+    ConfigLine(config_line='configure { system security aaa local-profiles profile "default" entry 10 }', parents=()),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "default" entry 10 action permit }',
+        parents=(),
+    ),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "default" entry 10 match "exec" }',
+        parents=(),
+    ),
+    ConfigLine(config_line='configure { system security aaa local-profiles profile "default" entry 20 }', parents=()),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "default" entry 20 action permit }',
+        parents=(),
+    ),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "default" entry 20 match "exit" }',
+        parents=(),
+    ),
+    ConfigLine(config_line='configure { system security aaa local-profiles profile "default" entry 30 }', parents=()),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "default" entry 30 action permit }',
+        parents=(),
+    ),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "default" entry 30 match "help" }',
+        parents=(),
+    ),
+    ConfigLine(config_line='configure { system security aaa local-profiles profile "default" entry 40 }', parents=()),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "default" entry 40 action permit }',
+        parents=(),
+    ),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "default" entry 40 match "logout" }',
+        parents=(),
+    ),
+    ConfigLine(config_line='configure { system security aaa local-profiles profile "default" entry 50 }', parents=()),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "default" entry 50 action permit }',
+        parents=(),
+    ),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "default" entry 50 match "password" }',
+        parents=(),
+    ),
+    ConfigLine(config_line='configure { system security aaa local-profiles profile "default" entry 60 }', parents=()),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "default" entry 60 action deny }',
+        parents=(),
+    ),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "default" entry 60 match "show config" }',
+        parents=(),
+    ),
+    ConfigLine(config_line='configure { system security aaa local-profiles profile "default" entry 65 }', parents=()),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "default" entry 65 action deny }',
+        parents=(),
+    ),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "default" entry 65 match "show li" }',
+        parents=(),
+    ),
+    ConfigLine(config_line='configure { system security aaa local-profiles profile "default" entry 66 }', parents=()),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "default" entry 66 action deny }',
+        parents=(),
+    ),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "default" entry 66 match "clear li" }',
+        parents=(),
+    ),
+    ConfigLine(config_line='configure { system security aaa local-profiles profile "default" entry 67 }', parents=()),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "default" entry 67 action deny }',
+        parents=(),
+    ),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "default" entry 67 match "tools dump li" }',
+        parents=(),
+    ),
+    ConfigLine(config_line='configure { system security aaa local-profiles profile "default" entry 68 }', parents=()),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "default" entry 68 action deny }',
+        parents=(),
+    ),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "default" entry 68 match "state li" }',
+        parents=(),
+    ),
+    ConfigLine(config_line='configure { system security aaa local-profiles profile "default" entry 70 }', parents=()),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "default" entry 70 action permit }',
+        parents=(),
+    ),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "default" entry 70 match "show" }',
+        parents=(),
+    ),
+    ConfigLine(config_line='configure { system security aaa local-profiles profile "default" entry 75 }', parents=()),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "default" entry 75 action permit }',
+        parents=(),
+    ),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "default" entry 75 match "state" }',
+        parents=(),
+    ),
+    ConfigLine(config_line='configure { system security aaa local-profiles profile "default" entry 80 }', parents=()),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "default" entry 80 action permit }',
+        parents=(),
+    ),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "default" entry 80 match "enable-admin" }',
+        parents=(),
+    ),
+    ConfigLine(config_line='configure { system security aaa local-profiles profile "default" entry 90 }', parents=()),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "default" entry 90 action permit }',
+        parents=(),
+    ),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "default" entry 90 match "enable" }',
+        parents=(),
+    ),
+    ConfigLine(config_line='configure { system security aaa local-profiles profile "default" entry 100 }', parents=()),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "default" entry 100 action deny }',
+        parents=(),
+    ),
+    ConfigLine(
+        config_line='configure { system security aaa local-profiles profile "default" entry 100 match "configure li" }',
+        parents=(),
+    ),
+    ConfigLine(config_line="configure { system security ssh }", parents=()),
+    ConfigLine(config_line="configure { system security ssh server-cipher-list-v1 }", parents=()),
+    ConfigLine(config_line="configure { system security ssh server-cipher-list-v1 cipher 200 }", parents=()),
+    ConfigLine(config_line="configure { system security ssh server-cipher-list-v1 cipher 200 name 3des }", parents=()),
+    ConfigLine(config_line="configure { system security ssh server-cipher-list-v1 cipher 205 }", parents=()),
+    ConfigLine(
+        config_line="configure { system security ssh server-cipher-list-v1 cipher 205 name blowfish }", parents=()
+    ),
+    ConfigLine(config_line="configure { system security ssh server-cipher-list-v2 }", parents=()),
+    ConfigLine(config_line="configure { system security ssh server-cipher-list-v2 cipher 190 }", parents=()),
+    ConfigLine(
+        config_line="configure { system security ssh server-cipher-list-v2 cipher 190 name aes256-ctr }", parents=()
+    ),
+    ConfigLine(config_line="configure { system security ssh server-cipher-list-v2 cipher 192 }", parents=()),
+    ConfigLine(
+        config_line="configure { system security ssh server-cipher-list-v2 cipher 192 name aes192-ctr }", parents=()
+    ),
+    ConfigLine(config_line="configure { system security ssh server-cipher-list-v2 cipher 194 }", parents=()),
+    ConfigLine(
+        config_line="configure { system security ssh server-cipher-list-v2 cipher 194 name aes128-ctr }", parents=()
+    ),
+    ConfigLine(config_line="configure { system security ssh server-cipher-list-v2 cipher 200 }", parents=()),
+    ConfigLine(
+        config_line="configure { system security ssh server-cipher-list-v2 cipher 200 name aes128-cbc }", parents=()
+    ),
+    ConfigLine(config_line="configure { system security ssh server-cipher-list-v2 cipher 205 }", parents=()),
+    ConfigLine(
+        config_line="configure { system security ssh server-cipher-list-v2 cipher 205 name 3des-cbc }", parents=()
+    ),
+    ConfigLine(config_line="configure { system security ssh server-cipher-list-v2 cipher 210 }", parents=()),
+    ConfigLine(
+        config_line="configure { system security ssh server-cipher-list-v2 cipher 210 name blowfish-cbc }", parents=()
+    ),
+    ConfigLine(config_line="configure { system security ssh server-cipher-list-v2 cipher 215 }", parents=()),
+    ConfigLine(
+        config_line="configure { system security ssh server-cipher-list-v2 cipher 215 name cast128-cbc }", parents=()
+    ),
+    ConfigLine(config_line="configure { system security ssh server-cipher-list-v2 cipher 220 }", parents=()),
+    ConfigLine(
+        config_line="configure { system security ssh server-cipher-list-v2 cipher 220 name arcfour }", parents=()
+    ),
+    ConfigLine(config_line="configure { system security ssh server-cipher-list-v2 cipher 225 }", parents=()),
+    ConfigLine(
+        config_line="configure { system security ssh server-cipher-list-v2 cipher 225 name aes192-cbc }", parents=()
+    ),
+    ConfigLine(config_line="configure { system security ssh server-cipher-list-v2 cipher 230 }", parents=()),
+    ConfigLine(
+        config_line="configure { system security ssh server-cipher-list-v2 cipher 230 name aes256-cbc }", parents=()
+    ),
+    ConfigLine(config_line="configure { system security ssh server-cipher-list-v2 cipher 235 }", parents=()),
+    ConfigLine(
+        config_line="configure { system security ssh server-cipher-list-v2 cipher 235 name rijndael-cbc }", parents=()
+    ),
+    ConfigLine(config_line="configure { system security ssh client-cipher-list-v1 }", parents=()),
+    ConfigLine(config_line="configure { system security ssh client-cipher-list-v1 cipher 200 }", parents=()),
+    ConfigLine(config_line="configure { system security ssh client-cipher-list-v1 cipher 200 name 3des }", parents=()),
+    ConfigLine(config_line="configure { system security ssh client-cipher-list-v1 cipher 205 }", parents=()),
+    ConfigLine(
+        config_line="configure { system security ssh client-cipher-list-v1 cipher 205 name blowfish }", parents=()
+    ),
+    ConfigLine(config_line="configure { system security ssh client-cipher-list-v1 cipher 210 }", parents=()),
+    ConfigLine(config_line="configure { system security ssh client-cipher-list-v1 cipher 210 name des }", parents=()),
+    ConfigLine(config_line="configure { system security ssh client-cipher-list-v2 }", parents=()),
+    ConfigLine(config_line="configure { system security ssh client-cipher-list-v2 cipher 190 }", parents=()),
+    ConfigLine(
+        config_line="configure { system security ssh client-cipher-list-v2 cipher 190 name aes256-ctr }", parents=()
+    ),
+    ConfigLine(config_line="configure { system security ssh client-cipher-list-v2 cipher 192 }", parents=()),
+    ConfigLine(
+        config_line="configure { system security ssh client-cipher-list-v2 cipher 192 name aes192-ctr }", parents=()
+    ),
+    ConfigLine(config_line="configure { system security ssh client-cipher-list-v2 cipher 194 }", parents=()),
+    ConfigLine(
+        config_line="configure { system security ssh client-cipher-list-v2 cipher 194 name aes128-ctr }", parents=()
+    ),
+    ConfigLine(config_line="configure { system security ssh client-cipher-list-v2 cipher 200 }", parents=()),
+    ConfigLine(
+        config_line="configure { system security ssh client-cipher-list-v2 cipher 200 name aes128-cbc }", parents=()
+    ),
+    ConfigLine(config_line="configure { system security ssh client-cipher-list-v2 cipher 205 }", parents=()),
+    ConfigLine(
+        config_line="configure { system security ssh client-cipher-list-v2 cipher 205 name 3des-cbc }", parents=()
+    ),
+    ConfigLine(config_line="configure { system security ssh client-cipher-list-v2 cipher 210 }", parents=()),
+    ConfigLine(
+        config_line="configure { system security ssh client-cipher-list-v2 cipher 210 name blowfish-cbc }", parents=()
+    ),
+    ConfigLine(config_line="configure { system security ssh client-cipher-list-v2 cipher 215 }", parents=()),
+    ConfigLine(
+        config_line="configure { system security ssh client-cipher-list-v2 cipher 215 name cast128-cbc }", parents=()
+    ),
+    ConfigLine(config_line="configure { system security ssh client-cipher-list-v2 cipher 220 }", parents=()),
+    ConfigLine(
+        config_line="configure { system security ssh client-cipher-list-v2 cipher 220 name arcfour }", parents=()
+    ),
+    ConfigLine(config_line="configure { system security ssh client-cipher-list-v2 cipher 225 }", parents=()),
+    ConfigLine(
+        config_line="configure { system security ssh client-cipher-list-v2 cipher 225 name aes192-cbc }", parents=()
+    ),
+    ConfigLine(config_line="configure { system security ssh client-cipher-list-v2 cipher 230 }", parents=()),
+    ConfigLine(
+        config_line="configure { system security ssh client-cipher-list-v2 cipher 230 name aes256-cbc }", parents=()
+    ),
+    ConfigLine(config_line="configure { system security ssh client-cipher-list-v2 cipher 235 }", parents=()),
+    ConfigLine(
+        config_line="configure { system security ssh client-cipher-list-v2 cipher 235 name rijndael-cbc }", parents=()
+    ),
+    ConfigLine(config_line="configure { system security ssh server-mac-list-v2 }", parents=()),
+    ConfigLine(config_line="configure { system security ssh server-mac-list-v2 mac 200 }", parents=()),
+    ConfigLine(
+        config_line="configure { system security ssh server-mac-list-v2 mac 200 name hmac-sha2-512 }", parents=()
+    ),
+    ConfigLine(config_line="configure { system security ssh server-mac-list-v2 mac 210 }", parents=()),
+    ConfigLine(
+        config_line="configure { system security ssh server-mac-list-v2 mac 210 name hmac-sha2-256 }", parents=()
+    ),
+    ConfigLine(config_line="configure { system security ssh server-mac-list-v2 mac 215 }", parents=()),
+    ConfigLine(config_line="configure { system security ssh server-mac-list-v2 mac 215 name hmac-sha1 }", parents=()),
+    ConfigLine(config_line="configure { system security ssh server-mac-list-v2 mac 220 }", parents=()),
+    ConfigLine(
+        config_line="configure { system security ssh server-mac-list-v2 mac 220 name hmac-sha1-96 }", parents=()
+    ),
+    ConfigLine(config_line="configure { system security ssh server-mac-list-v2 mac 225 }", parents=()),
+    ConfigLine(config_line="configure { system security ssh server-mac-list-v2 mac 225 name hmac-md5 }", parents=()),
+    ConfigLine(config_line="configure { system security ssh server-mac-list-v2 mac 230 }", parents=()),
+    ConfigLine(
+        config_line="configure { system security ssh server-mac-list-v2 mac 230 name hmac-ripemd160 }", parents=()
+    ),
+    ConfigLine(config_line="configure { system security ssh server-mac-list-v2 mac 235 }", parents=()),
+    ConfigLine(
+        config_line="configure { system security ssh server-mac-list-v2 mac 235 name hmac-ripemd160-openssh-com }",
+        parents=(),
+    ),
+    ConfigLine(config_line="configure { system security ssh server-mac-list-v2 mac 240 }", parents=()),
+    ConfigLine(config_line="configure { system security ssh server-mac-list-v2 mac 240 name hmac-md5-96 }", parents=()),
+    ConfigLine(config_line="configure { system security ssh client-mac-list-v2 }", parents=()),
+    ConfigLine(config_line="configure { system security ssh client-mac-list-v2 mac 200 }", parents=()),
+    ConfigLine(
+        config_line="configure { system security ssh client-mac-list-v2 mac 200 name hmac-sha2-512 }", parents=()
+    ),
+    ConfigLine(config_line="configure { system security ssh client-mac-list-v2 mac 210 }", parents=()),
+    ConfigLine(
+        config_line="configure { system security ssh client-mac-list-v2 mac 210 name hmac-sha2-256 }", parents=()
+    ),
+    ConfigLine(config_line="configure { system security ssh client-mac-list-v2 mac 215 }", parents=()),
+    ConfigLine(config_line="configure { system security ssh client-mac-list-v2 mac 215 name hmac-sha1 }", parents=()),
+    ConfigLine(config_line="configure { system security ssh client-mac-list-v2 mac 220 }", parents=()),
+    ConfigLine(
+        config_line="configure { system security ssh client-mac-list-v2 mac 220 name hmac-sha1-96 }", parents=()
+    ),
+    ConfigLine(config_line="configure { system security ssh client-mac-list-v2 mac 225 }", parents=()),
+    ConfigLine(config_line="configure { system security ssh client-mac-list-v2 mac 225 name hmac-md5 }", parents=()),
+    ConfigLine(config_line="configure { system security ssh client-mac-list-v2 mac 230 }", parents=()),
+    ConfigLine(
+        config_line="configure { system security ssh client-mac-list-v2 mac 230 name hmac-ripemd160 }", parents=()
+    ),
+    ConfigLine(config_line="configure { system security ssh client-mac-list-v2 mac 235 }", parents=()),
+    ConfigLine(
+        config_line="configure { system security ssh client-mac-list-v2 mac 235 name hmac-ripemd160-openssh-com }",
+        parents=(),
+    ),
+    ConfigLine(config_line="configure { system security ssh client-mac-list-v2 mac 240 }", parents=()),
+    ConfigLine(config_line="configure { system security ssh client-mac-list-v2 mac 240 name hmac-md5-96 }", parents=()),
+    ConfigLine(config_line="configure { system security user-params }", parents=()),
+    ConfigLine(config_line="configure { system security user-params local-user }", parents=()),
+    ConfigLine(config_line='configure { system security user-params local-user user "admin" }', parents=()),
+    ConfigLine(
+        config_line='configure { system security user-params local-user user "admin" password "$2y$10$TQrZlpBDra86.qoexZUzQeBXDY1FcdDhGWdD9lLxMuFyPVSm0OGy6" }',
+        parents=(),
+    ),
+    ConfigLine(config_line='configure { system security user-params local-user user "admin" access }', parents=()),
+    ConfigLine(
+        config_line='configure { system security user-params local-user user "admin" access console true }', parents=()
+    ),
+    ConfigLine(
+        config_line='configure { system security user-params local-user user "admin" access ftp true }', parents=()
+    ),
+    ConfigLine(
+        config_line='configure { system security user-params local-user user "admin" access snmp true }', parents=()
+    ),
+    ConfigLine(
+        config_line='configure { system security user-params local-user user "admin" access netconf true }', parents=()
+    ),
+    ConfigLine(
+        config_line='configure { system security user-params local-user user "admin" access grpc true }', parents=()
+    ),
+    ConfigLine(config_line='configure { system security user-params local-user user "admin" console }', parents=()),
+    ConfigLine(
+        config_line='configure { system security user-params local-user user "admin" console member ["administrative"] }',
+        parents=(),
+    ),
+]

--- a/tests/unit/mock/config/parser/nokia_sros/sros_full_sent.txt
+++ b/tests/unit/mock/config/parser/nokia_sros/sros_full_sent.txt
@@ -1,0 +1,256 @@
+configure { }
+configure { card 1 }
+configure { card 1 card-type iom-1 }
+configure { card 1 mda 1 }
+configure { card 1 mda 1 mda-type me12-100gb-qsfp28 }
+configure { card 1 mda 2 }
+configure { card 1 fp 1 }
+configure { log }
+configure { log filter "1001" }
+configure { log filter "1001" named-entry "10" }
+configure { log filter "1001" named-entry "10" description "Collect only events of major severity or higher" }
+configure { log filter "1001" named-entry "10" action forward }
+configure { log filter "1001" named-entry "10" match }
+configure { log filter "1001" named-entry "10" match severity }
+configure { log filter "1001" named-entry "10" match severity gte major }
+configure { log log-id "100" }
+configure { log log-id "100" description "Default Serious Errors Log" }
+configure { log log-id "100" filter "1001" }
+configure { log log-id "100" source }
+configure { log log-id "100" source main true }
+configure { log log-id "100" destination }
+configure { log log-id "100" destination memory }
+configure { log log-id "100" destination memory max-entries 500 }
+configure { log log-id "99" }
+configure { log log-id "99" description "Default System Log" }
+configure { log log-id "99" source }
+configure { log log-id "99" source main true }
+configure { log log-id "99" destination }
+configure { log log-id "99" destination memory }
+configure { log log-id "99" destination memory max-entries 500 }
+configure { port 1/1/c1 }
+configure { port 1/1/c2 }
+configure { port 1/1/c3 }
+configure { port 1/1/c4 }
+configure { port 1/1/c5 }
+configure { port 1/1/c6 }
+configure { port 1/1/c7 }
+configure { port 1/1/c8 }
+configure { port 1/1/c9 }
+configure { port 1/1/c10 }
+configure { port 1/1/c11 }
+configure { port 1/1/c12 }
+configure { router "Base" }
+configure { router "Base" interface "L3-OAM-eNodeB069420-W1" }
+configure { router "Base" interface "L3-OAM-eNodeB069420-W1" admin-state disable }
+configure { router "Base" interface "L3-OAM-eNodeB069420-W1" ingress-stats false }
+configure { system }
+configure { system name "core-router" }
+configure { system grpc }
+configure { system grpc admin-state enable }
+configure { system grpc allow-unsecure-connection }
+configure { system grpc gnmi }
+configure { system grpc gnmi auto-config-save true }
+configure { system grpc rib-api }
+configure { system grpc rib-api admin-state enable }
+configure { system management-interface }
+configure { system management-interface configuration-mode model-driven }
+configure { system management-interface netconf }
+configure { system management-interface netconf admin-state enable }
+configure { system management-interface netconf auto-config-save true }
+configure { system management-interface snmp }
+configure { system management-interface snmp packet-size 9216 }
+configure { system management-interface snmp streaming }
+configure { system management-interface snmp streaming admin-state enable }
+configure { system bluetooth }
+configure { system bluetooth advertising-timeout 30 }
+configure { system login-control }
+configure { system login-control ssh }
+configure { system login-control ssh inbound-max-sessions 30 }
+configure { system security }
+configure { system security aaa }
+configure { system security aaa local-profiles }
+configure { system security aaa local-profiles profile "administrative" }
+configure { system security aaa local-profiles profile "administrative" default-action permit-all }
+configure { system security aaa local-profiles profile "administrative" netconf }
+configure { system security aaa local-profiles profile "administrative" netconf base-op-authorization }
+configure { system security aaa local-profiles profile "administrative" netconf base-op-authorization kill-session true }
+configure { system security aaa local-profiles profile "administrative" netconf base-op-authorization lock true }
+configure { system security aaa local-profiles profile "administrative" entry 10 }
+configure { system security aaa local-profiles profile "administrative" entry 10 action permit }
+configure { system security aaa local-profiles profile "administrative" entry 10 match "configure system security" }
+configure { system security aaa local-profiles profile "administrative" entry 20 }
+configure { system security aaa local-profiles profile "administrative" entry 20 action permit }
+configure { system security aaa local-profiles profile "administrative" entry 20 match "show system security" }
+configure { system security aaa local-profiles profile "administrative" entry 30 }
+configure { system security aaa local-profiles profile "administrative" entry 30 action permit }
+configure { system security aaa local-profiles profile "administrative" entry 30 match "tools perform security" }
+configure { system security aaa local-profiles profile "administrative" entry 40 }
+configure { system security aaa local-profiles profile "administrative" entry 40 action permit }
+configure { system security aaa local-profiles profile "administrative" entry 40 match "tools dump security" }
+configure { system security aaa local-profiles profile "administrative" entry 50 }
+configure { system security aaa local-profiles profile "administrative" entry 50 action permit }
+configure { system security aaa local-profiles profile "administrative" entry 50 match "admin system security" }
+configure { system security aaa local-profiles profile "administrative" entry 100 }
+configure { system security aaa local-profiles profile "administrative" entry 100 action deny }
+configure { system security aaa local-profiles profile "administrative" entry 100 match "configure li" }
+configure { system security aaa local-profiles profile "administrative" entry 110 }
+configure { system security aaa local-profiles profile "administrative" entry 110 action deny }
+configure { system security aaa local-profiles profile "administrative" entry 110 match "show li" }
+configure { system security aaa local-profiles profile "administrative" entry 111 }
+configure { system security aaa local-profiles profile "administrative" entry 111 action deny }
+configure { system security aaa local-profiles profile "administrative" entry 111 match "clear li" }
+configure { system security aaa local-profiles profile "administrative" entry 112 }
+configure { system security aaa local-profiles profile "administrative" entry 112 action deny }
+configure { system security aaa local-profiles profile "administrative" entry 112 match "tools dump li" }
+configure { system security aaa local-profiles profile "default" }
+configure { system security aaa local-profiles profile "default" entry 10 }
+configure { system security aaa local-profiles profile "default" entry 10 action permit }
+configure { system security aaa local-profiles profile "default" entry 10 match "exec" }
+configure { system security aaa local-profiles profile "default" entry 20 }
+configure { system security aaa local-profiles profile "default" entry 20 action permit }
+configure { system security aaa local-profiles profile "default" entry 20 match "exit" }
+configure { system security aaa local-profiles profile "default" entry 30 }
+configure { system security aaa local-profiles profile "default" entry 30 action permit }
+configure { system security aaa local-profiles profile "default" entry 30 match "help" }
+configure { system security aaa local-profiles profile "default" entry 40 }
+configure { system security aaa local-profiles profile "default" entry 40 action permit }
+configure { system security aaa local-profiles profile "default" entry 40 match "logout" }
+configure { system security aaa local-profiles profile "default" entry 50 }
+configure { system security aaa local-profiles profile "default" entry 50 action permit }
+configure { system security aaa local-profiles profile "default" entry 50 match "password" }
+configure { system security aaa local-profiles profile "default" entry 60 }
+configure { system security aaa local-profiles profile "default" entry 60 action deny }
+configure { system security aaa local-profiles profile "default" entry 60 match "show config" }
+configure { system security aaa local-profiles profile "default" entry 65 }
+configure { system security aaa local-profiles profile "default" entry 65 action deny }
+configure { system security aaa local-profiles profile "default" entry 65 match "show li" }
+configure { system security aaa local-profiles profile "default" entry 66 }
+configure { system security aaa local-profiles profile "default" entry 66 action deny }
+configure { system security aaa local-profiles profile "default" entry 66 match "clear li" }
+configure { system security aaa local-profiles profile "default" entry 67 }
+configure { system security aaa local-profiles profile "default" entry 67 action deny }
+configure { system security aaa local-profiles profile "default" entry 67 match "tools dump li" }
+configure { system security aaa local-profiles profile "default" entry 68 }
+configure { system security aaa local-profiles profile "default" entry 68 action deny }
+configure { system security aaa local-profiles profile "default" entry 68 match "state li" }
+configure { system security aaa local-profiles profile "default" entry 70 }
+configure { system security aaa local-profiles profile "default" entry 70 action permit }
+configure { system security aaa local-profiles profile "default" entry 70 match "show" }
+configure { system security aaa local-profiles profile "default" entry 75 }
+configure { system security aaa local-profiles profile "default" entry 75 action permit }
+configure { system security aaa local-profiles profile "default" entry 75 match "state" }
+configure { system security aaa local-profiles profile "default" entry 80 }
+configure { system security aaa local-profiles profile "default" entry 80 action permit }
+configure { system security aaa local-profiles profile "default" entry 80 match "enable-admin" }
+configure { system security aaa local-profiles profile "default" entry 90 }
+configure { system security aaa local-profiles profile "default" entry 90 action permit }
+configure { system security aaa local-profiles profile "default" entry 90 match "enable" }
+configure { system security aaa local-profiles profile "default" entry 100 }
+configure { system security aaa local-profiles profile "default" entry 100 action deny }
+configure { system security aaa local-profiles profile "default" entry 100 match "configure li" }
+configure { system security ssh }
+configure { system security ssh server-cipher-list-v1 }
+configure { system security ssh server-cipher-list-v1 cipher 200 }
+configure { system security ssh server-cipher-list-v1 cipher 200 name 3des }
+configure { system security ssh server-cipher-list-v1 cipher 205 }
+configure { system security ssh server-cipher-list-v1 cipher 205 name blowfish }
+configure { system security ssh server-cipher-list-v2 }
+configure { system security ssh server-cipher-list-v2 cipher 190 }
+configure { system security ssh server-cipher-list-v2 cipher 190 name aes256-ctr }
+configure { system security ssh server-cipher-list-v2 cipher 192 }
+configure { system security ssh server-cipher-list-v2 cipher 192 name aes192-ctr }
+configure { system security ssh server-cipher-list-v2 cipher 194 }
+configure { system security ssh server-cipher-list-v2 cipher 194 name aes128-ctr }
+configure { system security ssh server-cipher-list-v2 cipher 200 }
+configure { system security ssh server-cipher-list-v2 cipher 200 name aes128-cbc }
+configure { system security ssh server-cipher-list-v2 cipher 205 }
+configure { system security ssh server-cipher-list-v2 cipher 205 name 3des-cbc }
+configure { system security ssh server-cipher-list-v2 cipher 210 }
+configure { system security ssh server-cipher-list-v2 cipher 210 name blowfish-cbc }
+configure { system security ssh server-cipher-list-v2 cipher 215 }
+configure { system security ssh server-cipher-list-v2 cipher 215 name cast128-cbc }
+configure { system security ssh server-cipher-list-v2 cipher 220 }
+configure { system security ssh server-cipher-list-v2 cipher 220 name arcfour }
+configure { system security ssh server-cipher-list-v2 cipher 225 }
+configure { system security ssh server-cipher-list-v2 cipher 225 name aes192-cbc }
+configure { system security ssh server-cipher-list-v2 cipher 230 }
+configure { system security ssh server-cipher-list-v2 cipher 230 name aes256-cbc }
+configure { system security ssh server-cipher-list-v2 cipher 235 }
+configure { system security ssh server-cipher-list-v2 cipher 235 name rijndael-cbc }
+configure { system security ssh client-cipher-list-v1 }
+configure { system security ssh client-cipher-list-v1 cipher 200 }
+configure { system security ssh client-cipher-list-v1 cipher 200 name 3des }
+configure { system security ssh client-cipher-list-v1 cipher 205 }
+configure { system security ssh client-cipher-list-v1 cipher 205 name blowfish }
+configure { system security ssh client-cipher-list-v1 cipher 210 }
+configure { system security ssh client-cipher-list-v1 cipher 210 name des }
+configure { system security ssh client-cipher-list-v2 }
+configure { system security ssh client-cipher-list-v2 cipher 190 }
+configure { system security ssh client-cipher-list-v2 cipher 190 name aes256-ctr }
+configure { system security ssh client-cipher-list-v2 cipher 192 }
+configure { system security ssh client-cipher-list-v2 cipher 192 name aes192-ctr }
+configure { system security ssh client-cipher-list-v2 cipher 194 }
+configure { system security ssh client-cipher-list-v2 cipher 194 name aes128-ctr }
+configure { system security ssh client-cipher-list-v2 cipher 200 }
+configure { system security ssh client-cipher-list-v2 cipher 200 name aes128-cbc }
+configure { system security ssh client-cipher-list-v2 cipher 205 }
+configure { system security ssh client-cipher-list-v2 cipher 205 name 3des-cbc }
+configure { system security ssh client-cipher-list-v2 cipher 210 }
+configure { system security ssh client-cipher-list-v2 cipher 210 name blowfish-cbc }
+configure { system security ssh client-cipher-list-v2 cipher 215 }
+configure { system security ssh client-cipher-list-v2 cipher 215 name cast128-cbc }
+configure { system security ssh client-cipher-list-v2 cipher 220 }
+configure { system security ssh client-cipher-list-v2 cipher 220 name arcfour }
+configure { system security ssh client-cipher-list-v2 cipher 225 }
+configure { system security ssh client-cipher-list-v2 cipher 225 name aes192-cbc }
+configure { system security ssh client-cipher-list-v2 cipher 230 }
+configure { system security ssh client-cipher-list-v2 cipher 230 name aes256-cbc }
+configure { system security ssh client-cipher-list-v2 cipher 235 }
+configure { system security ssh client-cipher-list-v2 cipher 235 name rijndael-cbc }
+configure { system security ssh server-mac-list-v2 }
+configure { system security ssh server-mac-list-v2 mac 200 }
+configure { system security ssh server-mac-list-v2 mac 200 name hmac-sha2-512 }
+configure { system security ssh server-mac-list-v2 mac 210 }
+configure { system security ssh server-mac-list-v2 mac 210 name hmac-sha2-256 }
+configure { system security ssh server-mac-list-v2 mac 215 }
+configure { system security ssh server-mac-list-v2 mac 215 name hmac-sha1 }
+configure { system security ssh server-mac-list-v2 mac 220 }
+configure { system security ssh server-mac-list-v2 mac 220 name hmac-sha1-96 }
+configure { system security ssh server-mac-list-v2 mac 225 }
+configure { system security ssh server-mac-list-v2 mac 225 name hmac-md5 }
+configure { system security ssh server-mac-list-v2 mac 230 }
+configure { system security ssh server-mac-list-v2 mac 230 name hmac-ripemd160 }
+configure { system security ssh server-mac-list-v2 mac 235 }
+configure { system security ssh server-mac-list-v2 mac 235 name hmac-ripemd160-openssh-com }
+configure { system security ssh server-mac-list-v2 mac 240 }
+configure { system security ssh server-mac-list-v2 mac 240 name hmac-md5-96 }
+configure { system security ssh client-mac-list-v2 }
+configure { system security ssh client-mac-list-v2 mac 200 }
+configure { system security ssh client-mac-list-v2 mac 200 name hmac-sha2-512 }
+configure { system security ssh client-mac-list-v2 mac 210 }
+configure { system security ssh client-mac-list-v2 mac 210 name hmac-sha2-256 }
+configure { system security ssh client-mac-list-v2 mac 215 }
+configure { system security ssh client-mac-list-v2 mac 215 name hmac-sha1 }
+configure { system security ssh client-mac-list-v2 mac 220 }
+configure { system security ssh client-mac-list-v2 mac 220 name hmac-sha1-96 }
+configure { system security ssh client-mac-list-v2 mac 225 }
+configure { system security ssh client-mac-list-v2 mac 225 name hmac-md5 }
+configure { system security ssh client-mac-list-v2 mac 230 }
+configure { system security ssh client-mac-list-v2 mac 230 name hmac-ripemd160 }
+configure { system security ssh client-mac-list-v2 mac 235 }
+configure { system security ssh client-mac-list-v2 mac 235 name hmac-ripemd160-openssh-com }
+configure { system security ssh client-mac-list-v2 mac 240 }
+configure { system security ssh client-mac-list-v2 mac 240 name hmac-md5-96 }
+configure { system security user-params }
+configure { system security user-params local-user }
+configure { system security user-params local-user user "admin" }
+configure { system security user-params local-user user "admin" password "$2y$10$TQrZlpBDra86.qoexZUzQeBXDY1FcdDhGWdD9lLxMuFyPVSm0OGy6" }
+configure { system security user-params local-user user "admin" access }
+configure { system security user-params local-user user "admin" access console true }
+configure { system security user-params local-user user "admin" access ftp true }
+configure { system security user-params local-user user "admin" access snmp true }
+configure { system security user-params local-user user "admin" access netconf true }
+configure { system security user-params local-user user "admin" access grpc true }
+configure { system security user-params local-user user "admin" console }
+configure { system security user-params local-user user "admin" console member ["administrative"] }


### PR DESCRIPTION
This PR includes changes for adding a Nokia SrOS parser. This requires that the configuration be presented in "info full-context" format as opposed to the indented MD-CLI format. This format is similar to Juniper's set format. I've included a test showing the parser working and I've added a note about the config format in the docs.