### PR TITLE
Fix decimal place in bits_to_name

### DIFF
--- a/netutils/bandwidth.py
+++ b/netutils/bandwidth.py
@@ -113,19 +113,20 @@ def bits_to_name(  # pylint: disable=too-many-branches,too-many-return-statement
     Example:
         >>> from netutils.bandwidth import bits_to_name
         >>> bits_to_name(125000)
-        '125.0Kbps'
+        '125Kbps'
         >>> bits_to_name(1000000000)
-        '1.0Gbps'
+        '1Gbps'
     """
     if not isinstance(speed, int):
         raise ValueError(f"Speed of {speed} was not a valid speed integer.")
 
     for bit_type, val in BITS_MAPPING.items():
         if val["low"] <= speed < val["high"]:
-            try:
-                return f"{round(speed / val['low'], nbr_decimal)}{bit_type}"
-            except ZeroDivisionError:
+            if nbr_decimal == 0:
+                nbr_decimal = None
+            if val["low"] == 0:
                 return f"{round(speed, nbr_decimal)}{bit_type}"
+            return f"{round(speed / val['low'], nbr_decimal)}{bit_type}"
     raise ValueError(f"Speed of {speed} was not a valid speed representation.")
 
 

--- a/tasks.py
+++ b/tasks.py
@@ -30,7 +30,7 @@ PYPROJECT_CONFIG = toml.load("pyproject.toml")
 TOOL_CONFIG = PYPROJECT_CONFIG["tool"]["poetry"]
 
 # Can be set to a separate Python version to be used for launching or building image
-PYTHON_VER = os.getenv("PYTHON_VER", "3.7")
+PYTHON_VER = os.getenv("PYTHON_VER", "3.9")
 # Name of the docker image/image
 IMAGE_NAME = os.getenv("IMAGE_NAME", TOOL_CONFIG["name"])
 # Tag for the image

--- a/tests/unit/test_bandwidth.py
+++ b/tests/unit/test_bandwidth.py
@@ -38,14 +38,15 @@ def test_name_to_bits_exceptions(data):
 
 bits_to_name = [
     {"sent": {"speed": 950}, "received": "950bps"},
-    {"sent": {"speed": 1000}, "received": "1.0Kbps"},
+    {"sent": {"speed": 1000}, "received": "1Kbps"},
     {"sent": {"speed": 1000, "nbr_decimal": 1}, "received": "1.0Kbps"},
-    {"sent": {"speed": 1000000}, "received": "1.0Mbps"},
+    {"sent": {"speed": 1000000}, "received": "1Mbps"},
     {"sent": {"speed": 1000000, "nbr_decimal": 1}, "received": "1.0Mbps"},
-    {"sent": {"speed": 1000000000}, "received": "1.0Gbps"},
+    {"sent": {"speed": 1000000000}, "received": "1Gbps"},
     {"sent": {"speed": 1000000000, "nbr_decimal": 1}, "received": "1.0Gbps"},
-    {"sent": {"speed": 1000000000000}, "received": "1.0Tbps"},
+    {"sent": {"speed": 1000000000000}, "received": "1Tbps"},
     {"sent": {"speed": 1000000000000, "nbr_decimal": 1}, "received": "1.0Tbps"},
+    {"sent": {"speed": 1234, "nbr_decimal": 0}, "received": "1Kbps"},
 ]
 
 

--- a/tests/unit/test_bandwidth.py
+++ b/tests/unit/test_bandwidth.py
@@ -43,6 +43,7 @@ bits_to_name = [
     {"sent": {"speed": 1000000}, "received": "1Mbps"},
     {"sent": {"speed": 1000000, "nbr_decimal": 1}, "received": "1.0Mbps"},
     {"sent": {"speed": 1000000000}, "received": "1Gbps"},
+    {"sent": {"speed": 1100000000, "nbr_decimal": 1}, "received": "1.1Gbps"},
     {"sent": {"speed": 1000000000, "nbr_decimal": 1}, "received": "1.0Gbps"},
     {"sent": {"speed": 1000000000000}, "received": "1Tbps"},
     {"sent": {"speed": 1000000000000, "nbr_decimal": 1}, "received": "1.0Tbps"},

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -2,8 +2,8 @@
 import subprocess
 import glob
 import os
-import pytest
 import re
+import pytest
 
 UNDOCUMENTED_FILES = ["__init__", "constants", "lib_mapper", "protocol_mapper", "variables"]
 

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -3,7 +3,7 @@ import subprocess
 import glob
 import os
 import pytest
-import regex
+import re
 
 UNDOCUMENTED_FILES = ["__init__", "constants", "lib_mapper", "protocol_mapper", "variables"]
 
@@ -54,7 +54,7 @@ def _get_readme_line(folder_name, start_end):
     regex_dict = {"start": r"(:start-line:\s+(?P<value>\d+))", "end": r"(:end-line:\s+(?P<value>\d+))"}
     with open(f"{SPHINX_DIRECTORIES[0]['source_dir']}/{folder_name}/index.rst", "r", encoding="utf-8") as index_file:
         for line in index_file.readlines():
-            match = regex.search(regex_dict[start_end], line)
+            match = re.search(regex_dict[start_end], line)
             if match:
                 break
 


### PR DESCRIPTION
This PR addresses issue #85. There appears to be a quirk with the round method that it will show the number as a float if you specify 0 decimal places and as an int, if you don't specify the places at all. This tweak should address the quirk and represent the name as expected.