### PR TITLE
Fixes encrypt type7

### DIFF
--- a/netutils/password.py
+++ b/netutils/password.py
@@ -142,7 +142,7 @@ def encrypt_type7(unencrypted_password, salt=None):
         salt (str, optional): A random number between 0 and 15 that can be set by the operator. Defaults to random generated one.
 
     Returns:
-        string (optional): The encrypted password.
+        str (optional): The encrypted password.
 
     Example:
         >>> from netutils.password import encrypt_type7

--- a/netutils/password.py
+++ b/netutils/password.py
@@ -202,32 +202,31 @@ def encrypt_type7(unencrypted_password, salt=None):
 
     Example:
         >>> from netutils.password import encrypt_type7
-        >>> encrypt_type5("cisco")  # doctest: +SKIP
+        >>> encrypt_type5("cisco")
         '094F471A1A0A'
         >>>
     """
     # max length of password for encrypt t7 is 25
-    if len(unencrypted_password) <= 25:
-        key_hex = []
-        for char in 'dsfd;kfoA,.iyewrkldJKDHSUBsgvca69834ncxv9873254k;fg87': # the same key is used in decrypt_type7 for the reverse operation
-            key_hex.append(hex(ord(char)))
-        if not salt:
-            salt = random.randint(0, 15)
-        # Start building the encrypted password - pre-pend the 2 decimal digit offset.
-        encrypted_password = format(salt, "02d")
-        for i, _ in enumerate(unencrypted_password):
-            # Get the next of the plaintext character.
-            dec_char = ord(unencrypted_password[i])
-            # Get the next character of the key.
-            key_char = ast.literal_eval(key_hex[(i + salt) % 53])
-            # XOR the plaintext character with the key character.
-            enc_char = dec_char ^ key_char
-            # Build the encrypted password one character at a time.
-            # The ASCII code of each encrypted character is added as 2 hex digits.
-            encrypted_password += format(enc_char, "02X")
-        return encrypted_password
-    else:
-        raise ValueError(f"Max password length must be 25.")
+    assert len(unencrypted_password) <= 25, "Password must not exceed 25 characters."
+    key_hex = []
+    # the same key string is used in decrypt_type7 for the reverse operation
+    for char in "dsfd;kfoA,.iyewrkldJKDHSUBsgvca69834ncxv9873254k;fg87":
+        key_hex.append(hex(ord(char)))
+    if not salt:
+        salt = random.randint(0, 15)
+    # Start building the encrypted password - pre-pend the 2 decimal digit offset.
+    encrypted_password = format(salt, "02d")
+    for i, _ in enumerate(unencrypted_password):
+        # Get the next of the plaintext character.
+        dec_char = ord(unencrypted_password[i])
+        # Get the next character of the key.
+        key_char = ast.literal_eval(key_hex[(i + salt) % 53])
+        # XOR the plaintext character with the key character.
+        enc_char = dec_char ^ key_char
+        # Build the encrypted password one character at a time.
+        # The ASCII code of each encrypted character is added as 2 hex digits.
+        encrypted_password += format(enc_char, "02X")
+    return encrypted_password
 
 
 def get_hash_salt(encrypted_password):

--- a/netutils/password.py
+++ b/netutils/password.py
@@ -150,30 +150,28 @@ def encrypt_type7(unencrypted_password, salt=None):
         '110A1016141D'
         >>>
     """
-    encrypted_password = ""  # nosec
     # max length of password for encrypt t7 is 25
     if len(unencrypted_password) > 25:  # nosec
         raise ValueError("Password must not exceed 25 characters.")
-        key_hex = []
-        # the same key string is used in decrypt_type7 for the reverse operation
-        for char in "dsfd;kfoA,.iyewrkldJKDHSUBsgvca69834ncxv9873254k;fg87":
-            key_hex.append(hex(ord(char)))
-        if not salt:
-            salt = random.randint(0, 15)  # nosec
-        # Start building the encrypted password - pre-pend the 2 decimal digit offset.
-        encrypted_password = format(salt, "02d")
-        for i, _ in enumerate(unencrypted_password):
-            # Get the next of the plaintext character.
-            dec_char = ord(unencrypted_password[i])
-            # Get the next character of the key.
-            key_char = ast.literal_eval(key_hex[(i + salt) % 53])
-            # XOR the plaintext character with the key character.
-            enc_char = dec_char ^ key_char
-            # Build the encrypted password one character at a time.
-            # The ASCII code of each encrypted character is added as 2 hex digits.
-            encrypted_password += format(enc_char, "02X")
-    else:
-        print("Password must not exceed 25 characters.")
+
+    key_hex = []
+    # the same key string is used in decrypt_type7 for the reverse operation
+    for char in "dsfd;kfoA,.iyewrkldJKDHSUBsgvca69834ncxv9873254k;fg87":
+        key_hex.append(hex(ord(char)))
+    if not salt:
+        salt = random.randint(0, 15)  # nosec
+    # Start building the encrypted password - pre-pend the 2 decimal digit offset.
+    encrypted_password = format(salt, "02d")
+    for i, _ in enumerate(unencrypted_password):
+        # Get the next of the plaintext character.
+        dec_char = ord(unencrypted_password[i])
+        # Get the next character of the key.
+        key_char = ast.literal_eval(key_hex[(i + salt) % 53])
+        # XOR the plaintext character with the key character.
+        enc_char = dec_char ^ key_char
+        # Build the encrypted password one character at a time.
+        # The ASCII code of each encrypted character is added as 2 hex digits.
+        encrypted_password += format(enc_char, "02X")
     return encrypted_password
 
 

--- a/netutils/password.py
+++ b/netutils/password.py
@@ -12,6 +12,63 @@ from functools import wraps
 ALPHABET = string.ascii_letters + string.digits
 DEFAULT_PASSWORD_CHARS = "".join((string.ascii_letters + string.digits + ".,:-_"))
 DEFAULT_PASSWORD_LENGTH = 20
+ENCRYPT_TYPE7_LENGTH = 25
+
+XLAT = [
+    "0x64",
+    "0x73",
+    "0x66",
+    "0x64",
+    "0x3b",
+    "0x6b",
+    "0x66",
+    "0x6f",
+    "0x41",
+    "0x2c",
+    "0x2e",
+    "0x69",
+    "0x79",
+    "0x65",
+    "0x77",
+    "0x72",
+    "0x6b",
+    "0x6c",
+    "0x64",
+    "0x4a",
+    "0x4b",
+    "0x44",
+    "0x48",
+    "0x53",
+    "0x55",
+    "0x42",
+    "0x73",
+    "0x67",
+    "0x76",
+    "0x63",
+    "0x61",
+    "0x36",
+    "0x39",
+    "0x38",
+    "0x33",
+    "0x34",
+    "0x6e",
+    "0x63",
+    "0x78",
+    "0x76",
+    "0x39",
+    "0x38",
+    "0x37",
+    "0x33",
+    "0x32",
+    "0x35",
+    "0x34",
+    "0x6b",
+    "0x3b",
+    "0x66",
+    "0x67",
+    "0x38",
+    "0x37",
+]
 
 
 def _fail_on_mac(func):
@@ -151,13 +208,13 @@ def encrypt_type7(unencrypted_password, salt=None):
         >>>
     """
     # max length of password for encrypt t7 is 25
-    if len(unencrypted_password) > 25:  # nosec
+    if len(unencrypted_password) > ENCRYPT_TYPE7_LENGTH:  # nosec
         raise ValueError("Password must not exceed 25 characters.")
 
-    key_hex = []
+    # key_hex = []
     # the same key string is used in decrypt_type7 for the reverse operation
-    for char in "dsfd;kfoA,.iyewrkldJKDHSUBsgvca69834ncxv9873254k;fg87":
-        key_hex.append(hex(ord(char)))
+    # for char in "dsfd;kfoA,.iyewrkldJKDHSUBsgvca69834ncxv9873254k;fg87":
+    #     key_hex.append(hex(ord(char)))
     if not salt:
         salt = random.randint(0, 15)  # nosec
     # Start building the encrypted password - pre-pend the 2 decimal digit offset.
@@ -166,7 +223,7 @@ def encrypt_type7(unencrypted_password, salt=None):
         # Get the next of the plaintext character.
         dec_char = ord(unencrypted_password[i])
         # Get the next character of the key.
-        key_char = ast.literal_eval(key_hex[(i + salt) % 53])
+        key_char = ast.literal_eval(XLAT[(i + salt) % 53])
         # XOR the plaintext character with the key character.
         enc_char = dec_char ^ key_char
         # Build the encrypted password one character at a time.

--- a/netutils/password.py
+++ b/netutils/password.py
@@ -13,62 +13,6 @@ ALPHABET = string.ascii_letters + string.digits
 DEFAULT_PASSWORD_CHARS = "".join((string.ascii_letters + string.digits + ".,:-_"))
 DEFAULT_PASSWORD_LENGTH = 20
 
-XLAT = [
-    0x64,
-    0x73,
-    0x66,
-    0x64,
-    0x3B,
-    0x6B,
-    0x66,
-    0x6F,
-    0x41,
-    0x2C,
-    0x2E,
-    0x69,
-    0x79,
-    0x65,
-    0x77,
-    0x72,
-    0x6B,
-    0x6C,
-    0x64,
-    0x4A,
-    0x4B,
-    0x44,
-    0x48,
-    0x53,
-    0x55,
-    0x42,
-    0x73,
-    0x67,
-    0x76,
-    0x63,
-    0x61,
-    0x36,
-    0x39,
-    0x38,
-    0x33,
-    0x34,
-    0x6E,
-    0x63,
-    0x78,
-    0x76,
-    0x39,
-    0x38,
-    0x37,
-    0x33,
-    0x32,
-    0x35,
-    0x34,
-    0x6B,
-    0x3B,
-    0x66,
-    0x67,
-    0x38,
-    0x37,
-]
-
 
 def _fail_on_mac(func):
     """There is an issue with Macintosh for encryption."""
@@ -202,30 +146,33 @@ def encrypt_type7(unencrypted_password, salt=None):
 
     Example:
         >>> from netutils.password import encrypt_type7
-        >>> encrypt_type5("cisco")
-        '094F471A1A0A'
+        >>> encrypt_type7("cisco", 11)
+        '110A1016141D'
         >>>
     """
+    encrypted_password = ""  # nosec
     # max length of password for encrypt t7 is 25
-    assert len(unencrypted_password) <= 25, "Password must not exceed 25 characters."
-    key_hex = []
-    # the same key string is used in decrypt_type7 for the reverse operation
-    for char in "dsfd;kfoA,.iyewrkldJKDHSUBsgvca69834ncxv9873254k;fg87":
-        key_hex.append(hex(ord(char)))
-    if not salt:
-        salt = random.randint(0, 15)
-    # Start building the encrypted password - pre-pend the 2 decimal digit offset.
-    encrypted_password = format(salt, "02d")
-    for i, _ in enumerate(unencrypted_password):
-        # Get the next of the plaintext character.
-        dec_char = ord(unencrypted_password[i])
-        # Get the next character of the key.
-        key_char = ast.literal_eval(key_hex[(i + salt) % 53])
-        # XOR the plaintext character with the key character.
-        enc_char = dec_char ^ key_char
-        # Build the encrypted password one character at a time.
-        # The ASCII code of each encrypted character is added as 2 hex digits.
-        encrypted_password += format(enc_char, "02X")
+    if len(unencrypted_password) <= 25:  # nosec
+        key_hex = []
+        # the same key string is used in decrypt_type7 for the reverse operation
+        for char in "dsfd;kfoA,.iyewrkldJKDHSUBsgvca69834ncxv9873254k;fg87":
+            key_hex.append(hex(ord(char)))
+        if not salt:
+            salt = random.randint(0, 15)  # nosec
+        # Start building the encrypted password - pre-pend the 2 decimal digit offset.
+        encrypted_password = format(salt, "02d")
+        for i, _ in enumerate(unencrypted_password):
+            # Get the next of the plaintext character.
+            dec_char = ord(unencrypted_password[i])
+            # Get the next character of the key.
+            key_char = ast.literal_eval(key_hex[(i + salt) % 53])
+            # XOR the plaintext character with the key character.
+            enc_char = dec_char ^ key_char
+            # Build the encrypted password one character at a time.
+            # The ASCII code of each encrypted character is added as 2 hex digits.
+            encrypted_password += format(enc_char, "02X")
+    else:
+        print("Password must not exceed 25 characters.")
     return encrypted_password
 
 

--- a/netutils/password.py
+++ b/netutils/password.py
@@ -211,10 +211,6 @@ def encrypt_type7(unencrypted_password, salt=None):
     if len(unencrypted_password) > ENCRYPT_TYPE7_LENGTH:  # nosec
         raise ValueError("Password must not exceed 25 characters.")
 
-    # key_hex = []
-    # the same key string is used in decrypt_type7 for the reverse operation
-    # for char in "dsfd;kfoA,.iyewrkldJKDHSUBsgvca69834ncxv9873254k;fg87":
-    #     key_hex.append(hex(ord(char)))
     if not salt:
         salt = random.randint(0, 15)  # nosec
     # Start building the encrypted password - pre-pend the 2 decimal digit offset.

--- a/netutils/password.py
+++ b/netutils/password.py
@@ -152,7 +152,8 @@ def encrypt_type7(unencrypted_password, salt=None):
     """
     encrypted_password = ""  # nosec
     # max length of password for encrypt t7 is 25
-    if len(unencrypted_password) <= 25:  # nosec
+    if len(unencrypted_password) > 25:  # nosec
+        raise ValueError("Password must not exceed 25 characters.")
         key_hex = []
         # the same key string is used in decrypt_type7 for the reverse operation
         for char in "dsfd;kfoA,.iyewrkldJKDHSUBsgvca69834ncxv9873254k;fg87":

--- a/tests/unit/test_password.py
+++ b/tests/unit/test_password.py
@@ -24,26 +24,26 @@ COMPARE_TYPE5 = [
 
 COMPARE_TYPE7 = [
     {
-        "sent": {"unencrypted_password": "cisco", "encrypted_password": "121A0C041104"},
+        "sent": {"unencrypted_password": "cisco", "encrypted_password": "070C285F4D06"},
         "received": True,
     },
     {
         "sent": {
             "unencrypted_password": "cisco",
-            "encrypted_password": "121A0C041104",
+            "encrypted_password": "070C285F4D06",
             "return_original": True,
         },
-        "received": "121A0C041104",
+        "received": "070C285F4D06",
     },
     {
-        "sent": {"unencrypted_password": "invalid_password", "encrypted_password": "121A0C041104"},
+        "sent": {"unencrypted_password": "invalid_password", "encrypted_password": "070C285F4D06"},
         "received": False,
     },
 ]
 
 DECRYPT_TYPE7 = [
     {
-        "sent": {"encrypted_password": "121A0C041104"},
+        "sent": {"encrypted_password": "14141B180F0B"},
         "received": "cisco",
     }
 ]
@@ -58,7 +58,7 @@ ENCRYPT_TYPE5 = [
 ENCRYPT_TYPE7 = [
     {
         "sent": {"unencrypted_password": "cisco", "salt": 10},
-        "received": "0a4d000a0618",
+        "received": "104D000A0618",
     },
 ]
 


### PR DESCRIPTION
Encrypt type7 is not working per issue https://github.com/networktocode/netutils/issues/108. Type 7 is fixed and a PoC using python interpreter is pasted below. For additional verification of the generate password you can use: https://www.firewall.cx/cisco-technical-knowledgebase/cisco-routers/358-cisco-type7-password-crack.html

```
from netutils.password import encrypt_type7, decrypt_type7
strings_to_encrypt = ['cisco', 'badpassword123', 'thisisnosecre *%+', 'the \chronicles of narnia', '123456789012345678901234567890']

for s in strings_to_encrypt:
    encrypted = encrypt_type7(s)
    print(encrypted)
    print(decrypt_type7(encrypted))

"""
070C285F4D06
cisco
130716161B0D17393C2B3A37647040
badpassword123
105A0110161E010503172F28362D737F6758
thisisnosecre *%+
061207240C720A1117181C020F082F38642735752C1215180A00

14141B180F0B
cisco
104C081D151601181B0B382F757A60
badpassword123
150603051723382A2720302101025649441D
thisisnosecre *%+
13111F174B300722392B263A362E1614560C07165759415A0702
the \chronicles of narnia

070C285F4D06
cisco
130716161B0D17393C2B3A37647040
badpassword123
120D0D1E01021F0A2538212B21306259425D
thisisnosecre *%+
0958460C5939141A19030A2328282D20752D1547180213585059
"""
```

Addresses https://github.com/networktocode/netutils/issues/108