### PR TITLE
Adding Cisco s350 compliance

### DIFF
--- a/netutils/config/compliance.py
+++ b/netutils/config/compliance.py
@@ -9,6 +9,7 @@ parser_map: t.Dict[str, t.Type[parser.BaseConfigParser]] = {
     "cisco_ios": parser.IOSConfigParser,
     "cisco_nxos": parser.NXOSConfigParser,
     "cisco_aireos": parser.AIREOSConfigParser,
+    "ciscos350": parser.IOSConfigParser,
     "linux": parser.LINUXConfigParser,
     "bigip_f5": parser.F5ConfigParser,
     "juniper_junos": parser.JunosConfigParser,

--- a/netutils/config/compliance.py
+++ b/netutils/config/compliance.py
@@ -9,7 +9,7 @@ parser_map: t.Dict[str, t.Type[parser.BaseConfigParser]] = {
     "cisco_ios": parser.IOSConfigParser,
     "cisco_nxos": parser.NXOSConfigParser,
     "cisco_aireos": parser.AIREOSConfigParser,
-    "ciscos350": parser.IOSConfigParser,
+    "ciscos300": parser.S300ConfigParser,
     "linux": parser.LINUXConfigParser,
     "bigip_f5": parser.F5ConfigParser,
     "juniper_junos": parser.JunosConfigParser,

--- a/netutils/config/parser.py
+++ b/netutils/config/parser.py
@@ -1104,4 +1104,4 @@ class S300ConfigParser(IOSConfigParser):
         Args:
             config (str): The config text to parse.
         """
-        super(IOSConfigParser, self).__init__(config)
+        super(S300ConfigParser, self).__init__(config)

--- a/netutils/config/parser.py
+++ b/netutils/config/parser.py
@@ -1093,3 +1093,15 @@ class NokiaConfigParser(BaseSpaceConfigParser):
                         config_lines.append(line.rstrip())
             self._config = "\n".join(config_lines)
         return self._config
+
+
+class S300ConfigParser(IOSConfigParser):
+    """Cisco S300 implementation of ConfigParser Class."""
+
+    def __init__(self, config: str):
+        """Create ConfigParser Object.
+
+        Args:
+            config (str): The config text to parse.
+        """
+        super(IOSConfigParser, self).__init__(config)


### PR DESCRIPTION
This PR Adds compliance parsing for the cisco s350 model switches.  For the purposes of this module they are identical to the cisco ios devices.