### PR TITLE
Fixed interface_range_expansion with trailing constant

### DIFF
--- a/netutils/interface.py
+++ b/netutils/interface.py
@@ -53,13 +53,20 @@ def interface_range_expansion(interface_pattern: str) -> t.List[str]:
         interface_constant.append(match.end())
         cartesian_list.append(_range_expand(match.group()[1:-1]))
 
+    # accommodate trailing constants
+    if interface_constant[-1] < len(interface_pattern):
+        interface_constant.append(len(interface_pattern))
+
     interface_constant_out = _pairwise(interface_constant)
     expanded_interfaces = []
     for element in itertools.product(*cartesian_list):
         current_interface = ""
         for count, item in enumerate(interface_constant_out):
             current_interface += interface_pattern[item[0] : item[1]]  # noqa: E203
-            current_interface += str(element[count])
+            # only append the next item if the current constant
+            # doesn't fall at the end of the line
+            if count < len(element):
+                current_interface += str(element[count])
         expanded_interfaces.append(current_interface)
 
     return expanded_interfaces

--- a/tests/unit/test_interface.py
+++ b/tests/unit/test_interface.py
@@ -177,6 +177,8 @@ INTERFACE_EXPANSION = [
     {"sent": "Gi[1,3-5]", "received": ["Gi1", "Gi3", "Gi4", "Gi5"]},
     {"sent": "Gi[1,3-5,8]", "received": ["Gi1", "Gi3", "Gi4", "Gi5", "Gi8"]},
     {"sent": "[1,2]/0/[1-2]", "received": ["1/0/1", "1/0/2", "2/0/1", "2/0/2"]},
+    {"sent": "Gi[1-3]/1", "received": ["Gi1/1", "Gi2/1", "Gi3/1"]},
+    {"sent": "Gi[1-3]/[1]", "received": ["Gi1/1", "Gi2/1", "Gi3/1"]},
 ]
 
 INTERFACE_SORT = [


### PR DESCRIPTION
## New Pull Request

Have you:
- [ ] ~Updated the README if necessary?~
- [ ] ~Updated any configuration settings?~
- [X] Written a unit test?

## Change Notes

This change fixed a bug where interface_range_expansion would drop any trailing constant from a range expansion. For instance, `Ethernet[1-3]/1` would expand to `["Ethernet1", "Ethernet2", "Ethernet3"]` without the trailing `/1`

## Justification

Bug fix.