### PR TITLE
fix: 🐛 strip 'devices localhost.localdomain' from set config

### DIFF
--- a/docs/dev/dev_config.md
+++ b/docs/dev/dev_config.md
@@ -26,6 +26,10 @@ The section banners have been simplified to extract the section header itself. T
 
 As the NetScaler configuration uses each line to make a specific configuration change there is no support for parent/child relationships in the parser.
 
+### Palo Alto Conversion 
+
+The conversion from curly to set format via the `paloalto_panos_brace_to_set` function strips any usage of `devices localhost.localdomain`. This will be evaluated in the future to be configurable but it is the current intention.
+
 ### Duplicate Line Detection
 
 In some circumstances replacing lines, such as secrets without uniqueness in the replacement, will result in duplicated lines that are invalid configuration, such as::

--- a/netutils/config/conversion.py
+++ b/netutils/config/conversion.py
@@ -91,4 +91,8 @@ def paloalto_panos_brace_to_set(cfg: str, cfg_type: str = "file") -> str:
         if _l < len(cfg_value) - 1:
             cfg_string += "\n"
 
+    # Filter out 'devices localhost.local domain' from the entire cfg_string
+    #FIXME: Add flagging capability to disable this behavior
+    cfg_string = cfg_string.replace("devices localhost.localdomain ", "")
+
     return cfg_string

--- a/netutils/config/conversion.py
+++ b/netutils/config/conversion.py
@@ -92,7 +92,7 @@ def paloalto_panos_brace_to_set(cfg: str, cfg_type: str = "file") -> str:
             cfg_string += "\n"
 
     # Filter out 'devices localhost.local domain' from the entire cfg_string
-    #FIXME: Add flagging capability to disable this behavior
+    # FIXME: Add flagging capability to disable this behavior
     cfg_string = cfg_string.replace("devices localhost.localdomain ", "")
 
     return cfg_string

--- a/netutils/config/conversion.py
+++ b/netutils/config/conversion.py
@@ -92,7 +92,7 @@ def paloalto_panos_brace_to_set(cfg: str, cfg_type: str = "file") -> str:
             cfg_string += "\n"
 
     # Filter out 'devices localhost.local domain' from the entire cfg_string
-    # FIXME: Add flagging capability to disable this behavior
+    # TODO: Add flagging capability to disable this behavior
     cfg_string = cfg_string.replace("devices localhost.localdomain ", "")
 
     return cfg_string

--- a/netutils/config/parser.py
+++ b/netutils/config/parser.py
@@ -1430,7 +1430,7 @@ class PaloAltoNetworksConfigParser(BaseSpaceConfigParser):
     banner_start: t.List[str] = [
         'set system login-banner "',
         'login-banner "',
-        'set devices localhost.localdomain deviceconfig system login-banner "',
+        'set deviceconfig system login-banner "',
     ]
     banner_end = '"'
 
@@ -1479,18 +1479,18 @@ class PaloAltoNetworksConfigParser(BaseSpaceConfigParser):
 
         Examples:
             >>> config = (
-            ...     "set devices localhost.localdomain deviceconfig system hostname firewall1\n"
-            ...     "set devices localhost.localdomain deviceconfig system panorama local-panorama panorama-server 10.0.0.1\n"
-            ...     "set devices localhost.localdomain deviceconfig system panorama local-panorama panorama-server-2 10.0.0.2\n"
-            ...     "set devices localhost.localdomain deviceconfig setting config rematch yes\n"
+            ...     "set deviceconfig system hostname firewall1\n"
+            ...     "set deviceconfig system panorama local-panorama panorama-server 10.0.0.1\n"
+            ...     "set deviceconfig system panorama local-panorama panorama-server-2 10.0.0.2\n"
+            ...     "set deviceconfig setting config rematch yes\n"
             ... )
             >>> config_tree = PaloAltoNetworksConfigParser(config)
             >>> config_tree.build_config_relationship() == \
             ... [
-            ...     ConfigLine(config_line="set devices localhost.localdomain deviceconfig system hostname firewall1", parents=()),
-            ...     ConfigLine(config_line="set devices localhost.localdomain deviceconfig system panorama local-panorama panorama-server 10.0.0.1", parents=()),
-            ...     ConfigLine(config_line="set devices localhost.localdomain deviceconfig system panorama local-panorama panorama-server-2 10.0.0.2", parents=()),
-            ...     ConfigLine(config_line="set devices localhost.localdomain deviceconfig setting config rematch yes", parents=()),
+            ...     ConfigLine(config_line="set deviceconfig system hostname firewall1", parents=()),
+            ...     ConfigLine(config_line="set deviceconfig system panorama local-panorama panorama-server 10.0.0.1", parents=()),
+            ...     ConfigLine(config_line="set deviceconfig system panorama local-panorama panorama-server-2 10.0.0.2", parents=()),
+            ...     ConfigLine(config_line="set deviceconfig setting config rematch yes", parents=()),
             ... ]
             True
         """

--- a/tests/unit/mock/config/compliance/section/paloalto_panos/panos_full_feature.py
+++ b/tests/unit/mock/config/compliance/section/paloalto_panos/panos_full_feature.py
@@ -1,5 +1,5 @@
 feature = {
     "name": "many",
     "ordered": True,
-    "section": ["set mgt-config", "set devices localhost.localdomain deviceconfig system panorama"],
+    "section": ["set mgt-config", "set deviceconfig system panorama"],
 }

--- a/tests/unit/mock/config/compliance/section/paloalto_panos/panos_full_received.txt
+++ b/tests/unit/mock/config/compliance/section/paloalto_panos/panos_full_received.txt
@@ -3,5 +3,5 @@ set mgt-config users admin permissions role-based superuser yes
 set mgt-config users admin public-key thisisasuperduperlongbase64encodedstring
 set mgt-config users panadmin permissions role-based superuser yes
 set mgt-config users panadmin phash passwordhash
-set devices localhost.localdomain deviceconfig system panorama local-panorama panorama-server 10.0.0.1
-set devices localhost.localdomain deviceconfig system panorama local-panorama panorama-server-2 10.0.0.2
+set deviceconfig system panorama local-panorama panorama-server 10.0.0.1
+set deviceconfig system panorama local-panorama panorama-server-2 10.0.0.2

--- a/tests/unit/mock/config/compliance/section/paloalto_panos/panos_full_sent.txt
+++ b/tests/unit/mock/config/compliance/section/paloalto_panos/panos_full_sent.txt
@@ -3,8 +3,8 @@ set mgt-config users admin permissions role-based superuser yes
 set mgt-config users admin public-key thisisasuperduperlongbase64encodedstring
 set mgt-config users panadmin permissions role-based superuser yes
 set mgt-config users panadmin phash passwordhash
-set devices localhost.localdomain deviceconfig system hostname firewall1
-set devices localhost.localdomain deviceconfig system login-banner "
+set deviceconfig system hostname firewall1
+set deviceconfig system login-banner "
 ************************************************************************
 *                        firewall1.example.com                         *                         [PROD VM500  firewalls]
 ************************************************************************
@@ -17,5 +17,5 @@ set devices localhost.localdomain deviceconfig system login-banner "
 *                                                                      *
 ************************************************************************
 "
-set devices localhost.localdomain deviceconfig system panorama local-panorama panorama-server 10.0.0.1
-set devices localhost.localdomain deviceconfig system panorama local-panorama panorama-server-2 10.0.0.2
+set deviceconfig system panorama local-panorama panorama-server 10.0.0.1
+set deviceconfig system panorama local-panorama panorama-server-2 10.0.0.2

--- a/tests/unit/mock/config/conversion/paloalto_panos/paloalto_basic_converted.txt
+++ b/tests/unit/mock/config/conversion/paloalto_panos/paloalto_basic_converted.txt
@@ -3,8 +3,8 @@ set mgt-config users admin permissions role-based superuser yes
 set mgt-config users admin public-key thisisasuperduperlongbase64encodedstring
 set mgt-config users panadmin permissions role-based superuser yes
 set mgt-config users panadmin phash passwordhash
-set devices localhost.localdomain deviceconfig system hostname firewall1
-set devices localhost.localdomain deviceconfig system login-banner "
+set deviceconfig system hostname firewall1
+set deviceconfig system login-banner "
 ************************************************************************
 *                        firewall1.example.com                         *                         [PROD VM500  firewalls]
 ************************************************************************
@@ -18,5 +18,5 @@ set devices localhost.localdomain deviceconfig system login-banner "
 ************************************************************************
 
 "
-set devices localhost.localdomain deviceconfig system panorama local-panorama panorama-server 10.0.0.1
-set devices localhost.localdomain deviceconfig system panorama local-panorama panorama-server-2 10.0.0.2
+set deviceconfig system panorama local-panorama panorama-server 10.0.0.1
+set deviceconfig system panorama local-panorama panorama-server-2 10.0.0.2

--- a/tests/unit/mock/config/parser/base/paloalto_panos/panos_basic_received.py
+++ b/tests/unit/mock/config/parser/base/paloalto_panos/panos_basic_received.py
@@ -22,23 +22,23 @@ data = [
         parents=(),
     ),
     ConfigLine(
-        config_line="set devices localhost.localdomain deviceconfig system hostname firewall1",
+        config_line="set deviceconfig system hostname firewall1",
         parents=(),
     ),
     ConfigLine(
-        config_line='set devices localhost.localdomain deviceconfig system login-banner "',
+        config_line='set deviceconfig system login-banner "',
         parents=(),
     ),
     ConfigLine(
         config_line="************************************************************************\n*                        firewall1.example.com                       *                         [PROD VM500  firewalls]\n************************************************************************\n*                               WARNING                                *\n*   Unauthorized access to this device or devices attached to          *\n*   or accessible from this network is strictly prohibited.            *\n*   Possession of passwords or devices enabling access to this         *\n*   device or devices does not constitute authorization. Unauthorized  *\n*   access will be prosecuted to the fullest extent of the law.        *\n*                                                                      *\n************************************************************************^C",
-        parents=('set devices localhost.localdomain deviceconfig system login-banner "',),
+        parents=('set deviceconfig system login-banner "',),
     ),
     ConfigLine(
-        config_line="set devices localhost.localdomain deviceconfig system panorama local-panorama panorama-server 10.0.0.1",
+        config_line="set deviceconfig system panorama local-panorama panorama-server 10.0.0.1",
         parents=(),
     ),
     ConfigLine(
-        config_line="set devices localhost.localdomain deviceconfig system panorama local-panorama panorama-server-2 10.0.0.2",
+        config_line="set deviceconfig system panorama local-panorama panorama-server-2 10.0.0.2",
         parents=(),
     ),
 ]

--- a/tests/unit/mock/config/parser/base/paloalto_panos/panos_full_received.py
+++ b/tests/unit/mock/config/parser/base/paloalto_panos/panos_full_received.py
@@ -63,278 +63,268 @@ data = [
     ConfigLine(config_line="set shared application-status notion-logout", parents=()),
     ConfigLine(config_line="set shared application-status notion-upload", parents=()),
     ConfigLine(
-        config_line="set devices localhost.localdomain network interface ethernet ethernet1/1 layer3 ipv6 neighbor-discovery router-advertisement enable no",
+        config_line="set network interface ethernet ethernet1/1 layer3 ipv6 neighbor-discovery router-advertisement enable no",
         parents=(),
     ),
     ConfigLine(
-        config_line="set devices localhost.localdomain network interface ethernet ethernet1/1 layer3 ndp-proxy enabled no",
+        config_line="set network interface ethernet ethernet1/1 layer3 ndp-proxy enabled no",
         parents=(),
     ),
     ConfigLine(
-        config_line="set devices localhost.localdomain network interface ethernet ethernet1/1 layer3 dhcp-client create-default-route yes",
+        config_line="set network interface ethernet ethernet1/1 layer3 dhcp-client create-default-route yes",
         parents=(),
     ),
     ConfigLine(
-        config_line="set devices localhost.localdomain network interface ethernet ethernet1/1 layer3 lldp enable no",
+        config_line="set network interface ethernet ethernet1/1 layer3 lldp enable no",
         parents=(),
     ),
     ConfigLine(
-        config_line="set devices localhost.localdomain network interface ethernet ethernet1/2 layer3 ipv6 neighbor-discovery router-advertisement enable no",
+        config_line="set network interface ethernet ethernet1/2 layer3 ipv6 neighbor-discovery router-advertisement enable no",
         parents=(),
     ),
     ConfigLine(
-        config_line="set devices localhost.localdomain network interface ethernet ethernet1/2 layer3 ndp-proxy enabled no",
+        config_line="set network interface ethernet ethernet1/2 layer3 ndp-proxy enabled no",
         parents=(),
     ),
     ConfigLine(
-        config_line="set devices localhost.localdomain network interface ethernet ethernet1/2 layer3 dhcp-client create-default-route no",
+        config_line="set network interface ethernet ethernet1/2 layer3 dhcp-client create-default-route no",
         parents=(),
     ),
     ConfigLine(
-        config_line="set devices localhost.localdomain network interface ethernet ethernet1/2 layer3 lldp enable no",
+        config_line="set network interface ethernet ethernet1/2 layer3 lldp enable no",
         parents=(),
     ),
     ConfigLine(
-        config_line="set devices localhost.localdomain network interface ethernet ethernet1/2 layer3 interface-management-profile mgt",
+        config_line="set network interface ethernet ethernet1/2 layer3 interface-management-profile mgt",
         parents=(),
     ),
     ConfigLine(
-        config_line="set devices localhost.localdomain network interface ethernet ethernet1/2 link-state auto",
+        config_line="set network interface ethernet ethernet1/2 link-state auto",
+        parents=(),
+    ),
+    ConfigLine(config_line="set network profiles monitor-profile default interval 3", parents=()),
+    ConfigLine(config_line="set network profiles monitor-profile default threshold 5", parents=()),
+    ConfigLine(
+        config_line="set network profiles monitor-profile default action wait-recover",
+        parents=(),
+    ),
+    ConfigLine(config_line="set network profiles interface-management-profile", parents=()),
+    ConfigLine(
+        config_line="set network ike crypto-profiles ike-crypto-profiles default encryption [ aes-128-cbc 3des]",
         parents=(),
     ),
     ConfigLine(
-        config_line="set devices localhost.localdomain network profiles monitor-profile default interval 3", parents=()
-    ),
-    ConfigLine(
-        config_line="set devices localhost.localdomain network profiles monitor-profile default threshold 5", parents=()
-    ),
-    ConfigLine(
-        config_line="set devices localhost.localdomain network profiles monitor-profile default action wait-recover",
+        config_line="set network ike crypto-profiles ike-crypto-profiles default hash sha1",
         parents=(),
     ),
     ConfigLine(
-        config_line="set devices localhost.localdomain network profiles interface-management-profile", parents=()
-    ),
-    ConfigLine(
-        config_line="set devices localhost.localdomain network ike crypto-profiles ike-crypto-profiles default encryption [ aes-128-cbc 3des]",
+        config_line="set network ike crypto-profiles ike-crypto-profiles default dh-group group2",
         parents=(),
     ),
     ConfigLine(
-        config_line="set devices localhost.localdomain network ike crypto-profiles ike-crypto-profiles default hash sha1",
+        config_line="set network ike crypto-profiles ike-crypto-profiles default lifetime hours 8",
         parents=(),
     ),
     ConfigLine(
-        config_line="set devices localhost.localdomain network ike crypto-profiles ike-crypto-profiles default dh-group group2",
+        config_line="set network ike crypto-profiles ike-crypto-profiles Suite-B-GCM-128 encryption aes-128-cbc",
         parents=(),
     ),
     ConfigLine(
-        config_line="set devices localhost.localdomain network ike crypto-profiles ike-crypto-profiles default lifetime hours 8",
+        config_line="set network ike crypto-profiles ike-crypto-profiles Suite-B-GCM-128 hash sha256",
         parents=(),
     ),
     ConfigLine(
-        config_line="set devices localhost.localdomain network ike crypto-profiles ike-crypto-profiles Suite-B-GCM-128 encryption aes-128-cbc",
+        config_line="set network ike crypto-profiles ike-crypto-profiles Suite-B-GCM-128 dh-group group19",
         parents=(),
     ),
     ConfigLine(
-        config_line="set devices localhost.localdomain network ike crypto-profiles ike-crypto-profiles Suite-B-GCM-128 hash sha256",
+        config_line="set network ike crypto-profiles ike-crypto-profiles Suite-B-GCM-128 lifetime hours 8",
         parents=(),
     ),
     ConfigLine(
-        config_line="set devices localhost.localdomain network ike crypto-profiles ike-crypto-profiles Suite-B-GCM-128 dh-group group19",
+        config_line="set network ike crypto-profiles ike-crypto-profiles Suite-B-GCM-256 encryption aes-256-cbc",
         parents=(),
     ),
     ConfigLine(
-        config_line="set devices localhost.localdomain network ike crypto-profiles ike-crypto-profiles Suite-B-GCM-128 lifetime hours 8",
+        config_line="set network ike crypto-profiles ike-crypto-profiles Suite-B-GCM-256 hash sha384",
         parents=(),
     ),
     ConfigLine(
-        config_line="set devices localhost.localdomain network ike crypto-profiles ike-crypto-profiles Suite-B-GCM-256 encryption aes-256-cbc",
+        config_line="set network ike crypto-profiles ike-crypto-profiles Suite-B-GCM-256 dh-group group20",
         parents=(),
     ),
     ConfigLine(
-        config_line="set devices localhost.localdomain network ike crypto-profiles ike-crypto-profiles Suite-B-GCM-256 hash sha384",
+        config_line="set network ike crypto-profiles ike-crypto-profiles Suite-B-GCM-256 lifetime hours 8",
         parents=(),
     ),
     ConfigLine(
-        config_line="set devices localhost.localdomain network ike crypto-profiles ike-crypto-profiles Suite-B-GCM-256 dh-group group20",
+        config_line="set network ike crypto-profiles ipsec-crypto-profiles default esp encryption [ aes-128-cbc 3des]",
         parents=(),
     ),
     ConfigLine(
-        config_line="set devices localhost.localdomain network ike crypto-profiles ike-crypto-profiles Suite-B-GCM-256 lifetime hours 8",
+        config_line="set network ike crypto-profiles ipsec-crypto-profiles default esp authentication sha1",
         parents=(),
     ),
     ConfigLine(
-        config_line="set devices localhost.localdomain network ike crypto-profiles ipsec-crypto-profiles default esp encryption [ aes-128-cbc 3des]",
+        config_line="set network ike crypto-profiles ipsec-crypto-profiles default dh-group group2",
         parents=(),
     ),
     ConfigLine(
-        config_line="set devices localhost.localdomain network ike crypto-profiles ipsec-crypto-profiles default esp authentication sha1",
+        config_line="set network ike crypto-profiles ipsec-crypto-profiles default lifetime hours 1",
         parents=(),
     ),
     ConfigLine(
-        config_line="set devices localhost.localdomain network ike crypto-profiles ipsec-crypto-profiles default dh-group group2",
+        config_line="set network ike crypto-profiles ipsec-crypto-profiles Suite-B-GCM-128 esp encryption aes-128-gcm",
         parents=(),
     ),
     ConfigLine(
-        config_line="set devices localhost.localdomain network ike crypto-profiles ipsec-crypto-profiles default lifetime hours 1",
+        config_line="set network ike crypto-profiles ipsec-crypto-profiles Suite-B-GCM-128 esp authentication none",
         parents=(),
     ),
     ConfigLine(
-        config_line="set devices localhost.localdomain network ike crypto-profiles ipsec-crypto-profiles Suite-B-GCM-128 esp encryption aes-128-gcm",
+        config_line="set network ike crypto-profiles ipsec-crypto-profiles Suite-B-GCM-128 dh-group group19",
         parents=(),
     ),
     ConfigLine(
-        config_line="set devices localhost.localdomain network ike crypto-profiles ipsec-crypto-profiles Suite-B-GCM-128 esp authentication none",
+        config_line="set network ike crypto-profiles ipsec-crypto-profiles Suite-B-GCM-128 lifetime hours 1",
         parents=(),
     ),
     ConfigLine(
-        config_line="set devices localhost.localdomain network ike crypto-profiles ipsec-crypto-profiles Suite-B-GCM-128 dh-group group19",
+        config_line="set network ike crypto-profiles ipsec-crypto-profiles Suite-B-GCM-256 esp encryption aes-256-gcm",
         parents=(),
     ),
     ConfigLine(
-        config_line="set devices localhost.localdomain network ike crypto-profiles ipsec-crypto-profiles Suite-B-GCM-128 lifetime hours 1",
+        config_line="set network ike crypto-profiles ipsec-crypto-profiles Suite-B-GCM-256 esp authentication none",
         parents=(),
     ),
     ConfigLine(
-        config_line="set devices localhost.localdomain network ike crypto-profiles ipsec-crypto-profiles Suite-B-GCM-256 esp encryption aes-256-gcm",
+        config_line="set network ike crypto-profiles ipsec-crypto-profiles Suite-B-GCM-256 dh-group group20",
         parents=(),
     ),
     ConfigLine(
-        config_line="set devices localhost.localdomain network ike crypto-profiles ipsec-crypto-profiles Suite-B-GCM-256 esp authentication none",
+        config_line="set network ike crypto-profiles ipsec-crypto-profiles Suite-B-GCM-256 lifetime hours 1",
         parents=(),
     ),
     ConfigLine(
-        config_line="set devices localhost.localdomain network ike crypto-profiles ipsec-crypto-profiles Suite-B-GCM-256 dh-group group20",
+        config_line="set network ike crypto-profiles global-protect-app-crypto-profiles default encryption aes-128-cbc",
         parents=(),
     ),
     ConfigLine(
-        config_line="set devices localhost.localdomain network ike crypto-profiles ipsec-crypto-profiles Suite-B-GCM-256 lifetime hours 1",
+        config_line="set network ike crypto-profiles global-protect-app-crypto-profiles default authentication sha1",
         parents=(),
     ),
     ConfigLine(
-        config_line="set devices localhost.localdomain network ike crypto-profiles global-protect-app-crypto-profiles default encryption aes-128-cbc",
+        config_line="set network qos profile default class-bandwidth-type mbps class class1 priority real-time",
         parents=(),
     ),
     ConfigLine(
-        config_line="set devices localhost.localdomain network ike crypto-profiles global-protect-app-crypto-profiles default authentication sha1",
+        config_line="set network qos profile default class-bandwidth-type mbps class class2 priority high",
         parents=(),
     ),
     ConfigLine(
-        config_line="set devices localhost.localdomain network qos profile default class-bandwidth-type mbps class class1 priority real-time",
+        config_line="set network qos profile default class-bandwidth-type mbps class class3 priority high",
         parents=(),
     ),
     ConfigLine(
-        config_line="set devices localhost.localdomain network qos profile default class-bandwidth-type mbps class class2 priority high",
+        config_line="set network qos profile default class-bandwidth-type mbps class class4 priority medium",
         parents=(),
     ),
     ConfigLine(
-        config_line="set devices localhost.localdomain network qos profile default class-bandwidth-type mbps class class3 priority high",
+        config_line="set network qos profile default class-bandwidth-type mbps class class5 priority medium",
         parents=(),
     ),
     ConfigLine(
-        config_line="set devices localhost.localdomain network qos profile default class-bandwidth-type mbps class class4 priority medium",
+        config_line="set network qos profile default class-bandwidth-type mbps class class6 priority low",
         parents=(),
     ),
     ConfigLine(
-        config_line="set devices localhost.localdomain network qos profile default class-bandwidth-type mbps class class5 priority medium",
+        config_line="set network qos profile default class-bandwidth-type mbps class class7 priority low",
         parents=(),
     ),
     ConfigLine(
-        config_line="set devices localhost.localdomain network qos profile default class-bandwidth-type mbps class class6 priority low",
+        config_line="set network qos profile default class-bandwidth-type mbps class class8 priority low",
+        parents=(),
+    ),
+    ConfigLine(config_line="set network virtual-router", parents=()),
+    ConfigLine(
+        config_line="set deviceconfig system type dhcp-client send-hostname yes",
         parents=(),
     ),
     ConfigLine(
-        config_line="set devices localhost.localdomain network qos profile default class-bandwidth-type mbps class class7 priority low",
+        config_line="set deviceconfig system type dhcp-client send-client-id yes",
         parents=(),
     ),
     ConfigLine(
-        config_line="set devices localhost.localdomain network qos profile default class-bandwidth-type mbps class class8 priority low",
-        parents=(),
-    ),
-    ConfigLine(config_line="set devices localhost.localdomain network virtual-router", parents=()),
-    ConfigLine(
-        config_line="set devices localhost.localdomain deviceconfig system type dhcp-client send-hostname yes",
+        config_line="set deviceconfig system type dhcp-client accept-dhcp-hostname no",
         parents=(),
     ),
     ConfigLine(
-        config_line="set devices localhost.localdomain deviceconfig system type dhcp-client send-client-id yes",
+        config_line="set deviceconfig system type dhcp-client accept-dhcp-domain yes",
         parents=(),
     ),
     ConfigLine(
-        config_line="set devices localhost.localdomain deviceconfig system type dhcp-client accept-dhcp-hostname no",
+        config_line="set deviceconfig system update-server updates.paloaltonetworks.com",
         parents=(),
     ),
-    ConfigLine(
-        config_line="set devices localhost.localdomain deviceconfig system type dhcp-client accept-dhcp-domain yes",
-        parents=(),
-    ),
-    ConfigLine(
-        config_line="set devices localhost.localdomain deviceconfig system update-server updates.paloaltonetworks.com",
-        parents=(),
-    ),
-    ConfigLine(config_line="set devices localhost.localdomain deviceconfig system update-schedule", parents=()),
-    ConfigLine(
-        config_line="set devices localhost.localdomain deviceconfig system service disable-telnet yes", parents=()
-    ),
-    ConfigLine(
-        config_line="set devices localhost.localdomain deviceconfig system service disable-http yes", parents=()
-    ),
-    ConfigLine(config_line="set devices localhost.localdomain deviceconfig system hostname firewall1", parents=()),
-    ConfigLine(config_line='set devices localhost.localdomain deviceconfig system login-banner "', parents=()),
+    ConfigLine(config_line="set deviceconfig system update-schedule", parents=()),
+    ConfigLine(config_line="set deviceconfig system service disable-telnet yes", parents=()),
+    ConfigLine(config_line="set deviceconfig system service disable-http yes", parents=()),
+    ConfigLine(config_line="set deviceconfig system hostname firewall1", parents=()),
+    ConfigLine(config_line='set deviceconfig system login-banner "', parents=()),
     ConfigLine(
         config_line="************************************************************************\n*                        firewall1.example.com                       *                         [PROD VM500  firewalls]\n************************************************************************\n*                               WARNING                                *\n*   Unauthorized access to this device or devices attached to          *\n*   or accessible from this network is strictly prohibited.            *\n*   Possession of passwords or devices enabling access to this         *\n*   device or devices does not constitute authorization. Unauthorized  *\n*   access will be prosecuted to the fullest extent of the law.        *\n*                                                                      *\n************************************************************************^C",
-        parents=('set devices localhost.localdomain deviceconfig system login-banner "',),
+        parents=('set deviceconfig system login-banner "',),
     ),
     ConfigLine(
-        config_line="set devices localhost.localdomain deviceconfig system panorama local-panorama panorama-server 10.0.0.1",
+        config_line="set deviceconfig system panorama local-panorama panorama-server 10.0.0.1",
         parents=(),
     ),
     ConfigLine(
-        config_line="set devices localhost.localdomain deviceconfig system panorama local-panorama panorama-server-2 10.0.0.2",
+        config_line="set deviceconfig system panorama local-panorama panorama-server-2 10.0.0.2",
         parents=(),
     ),
-    ConfigLine(config_line="set devices localhost.localdomain deviceconfig setting config rematch yes", parents=()),
+    ConfigLine(config_line="set deviceconfig setting config rematch yes", parents=()),
     ConfigLine(
-        config_line="set devices localhost.localdomain deviceconfig setting management hostname-type-in-syslog FQDN",
-        parents=(),
-    ),
-    ConfigLine(
-        config_line="set devices localhost.localdomain deviceconfig setting management initcfg public-key thisisasuperduperlongbase64encodedstring=",
+        config_line="set deviceconfig setting management hostname-type-in-syslog FQDN",
         parents=(),
     ),
     ConfigLine(
-        config_line="set devices localhost.localdomain deviceconfig setting management initcfg type dhcp-client send-hostname yes",
+        config_line="set deviceconfig setting management initcfg public-key thisisasuperduperlongbase64encodedstring=",
         parents=(),
     ),
     ConfigLine(
-        config_line="set devices localhost.localdomain deviceconfig setting management initcfg type dhcp-client send-client-id yes",
+        config_line="set deviceconfig setting management initcfg type dhcp-client send-hostname yes",
         parents=(),
     ),
     ConfigLine(
-        config_line="set devices localhost.localdomain deviceconfig setting management initcfg type dhcp-client accept-dhcp-hostname yes",
+        config_line="set deviceconfig setting management initcfg type dhcp-client send-client-id yes",
         parents=(),
     ),
     ConfigLine(
-        config_line="set devices localhost.localdomain deviceconfig setting management initcfg type dhcp-client accept-dhcp-domain yes",
+        config_line="set deviceconfig setting management initcfg type dhcp-client accept-dhcp-hostname yes",
         parents=(),
     ),
     ConfigLine(
-        config_line="set devices localhost.localdomain deviceconfig setting management initcfg dns-primary 8.8.8.8",
+        config_line="set deviceconfig setting management initcfg type dhcp-client accept-dhcp-domain yes",
         parents=(),
     ),
     ConfigLine(
-        config_line="set devices localhost.localdomain deviceconfig setting management initcfg op-command-modes mgmt-interface-swap",
+        config_line="set deviceconfig setting management initcfg dns-primary 8.8.8.8",
         parents=(),
     ),
-    ConfigLine(config_line="set devices localhost.localdomain vsys vsys1 zone", parents=()),
     ConfigLine(
-        config_line="set devices localhost.localdomain vsys vsys1 import network interface [ ethernet1/1 ethernet1/2 vlan loopback tunnel]",
+        config_line="set deviceconfig setting management initcfg op-command-modes mgmt-interface-swap",
         parents=(),
     ),
-    ConfigLine(config_line="set devices localhost.localdomain vsys vsys1 import network vlan", parents=()),
-    ConfigLine(config_line="set devices localhost.localdomain vsys vsys1 import network virtual-router", parents=()),
-    ConfigLine(config_line="set devices localhost.localdomain vsys vsys1 import network virtual-wire", parents=()),
-    ConfigLine(config_line="set devices localhost.localdomain vsys vsys1 address", parents=()),
-    ConfigLine(config_line="set devices localhost.localdomain vsys vsys1 rulebase security rules", parents=()),
-    ConfigLine(config_line="set devices localhost.localdomain vsys vsys1 service", parents=()),
+    ConfigLine(config_line="set vsys vsys1 zone", parents=()),
+    ConfigLine(
+        config_line="set vsys vsys1 import network interface [ ethernet1/1 ethernet1/2 vlan loopback tunnel]",
+        parents=(),
+    ),
+    ConfigLine(config_line="set vsys vsys1 import network vlan", parents=()),
+    ConfigLine(config_line="set vsys vsys1 import network virtual-router", parents=()),
+    ConfigLine(config_line="set vsys vsys1 import network virtual-wire", parents=()),
+    ConfigLine(config_line="set vsys vsys1 address", parents=()),
+    ConfigLine(config_line="set vsys vsys1 rulebase security rules", parents=()),
+    ConfigLine(config_line="set vsys vsys1 service", parents=()),
 ]


### PR DESCRIPTION
## New Pull Request

Have you:
- [X] Updated the README if necessary?
- [X] Updated any configuration settings?
- [X] Written a unit test?

## Change Notes

- Strip 'devices localhost.localdomain' from set configuration.

## Justification

- Those commands do not exist in the set configuration mode.
