### PR TITLE
Add classy docs to view config parser classes

### DIFF
--- a/docs/dev/classy/parser.md
+++ b/docs/dev/classy/parser.md
@@ -1,0 +1,4 @@
+---
+classy_dotted_path: netutils.config.parser.BaseConfigParser
+---
+# Classy Doc

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,7 @@
 mkdocs==1.4.3
 # Material for MkDocs theme
 mkdocs-material==8.5.8
+mkdocs-python-classy==0.1.2
 # Render custom markdown for version added/changed/remove notes
 mkdocs-version-annotations==1.0.0
 # Automatic documentation from sources, for MkDocs

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,6 +82,12 @@ markdown_extensions:
 plugins:
   - "search"
   - "mkdocs-version-annotations"
+  - "mkdocs-python-classy":
+      classy_strategy: "subclass"
+      classy_modules:
+        - "netutils.config.parser"
+      classy_libraries:
+        - "netutils"
   - "mkdocstrings":
       default_handler: "python"
       handlers:
@@ -144,3 +150,5 @@ nav:
           - Time: "dev/code_reference/time.md"
           - Utils: "dev/code_reference/utils.md"
           - VLAN: "dev/code_reference/vlan.md"
+      - Classy Docs:
+          - Parser: "dev/classy/parser.md"

--- a/poetry.lock
+++ b/poetry.lock
@@ -31,6 +31,21 @@ wrapt = [
 ]
 
 [[package]]
+name = "astunparse"
+version = "1.6.3"
+description = "An AST unparser for Python"
+optional = false
+python-versions = "*"
+files = [
+    {file = "astunparse-1.6.3-py2.py3-none-any.whl", hash = "sha256:c2652417f2c8b5bb325c885ae329bdf3f86424075c4fd1a128674bc6fba4b8e8"},
+    {file = "astunparse-1.6.3.tar.gz", hash = "sha256:5ad93a8456f0d084c3456d059fd9a92cce667963232cbf763eac3bc5b7940872"},
+]
+
+[package.dependencies]
+six = ">=1.6.1,<2.0"
+wheel = ">=0.23.0,<1.0"
+
+[[package]]
 name = "babel"
 version = "2.12.1"
 description = "Internationalization utilities"
@@ -1066,6 +1081,22 @@ files = [
 ]
 
 [[package]]
+name = "mkdocs-python-classy"
+version = "0.1.2"
+description = "Mkdocs plugin to view Python Classes."
+optional = false
+python-versions = ">=3.8,<4.0"
+files = [
+    {file = "mkdocs_python_classy-0.1.2-py3-none-any.whl", hash = "sha256:73843815a6aec1ce2088177a5920b5df7f3d208291e21b82dbd1c40271adb42f"},
+    {file = "mkdocs_python_classy-0.1.2.tar.gz", hash = "sha256:89e7053e2a30351a068108e6a337479d77db8c1f3e74f3e3507a1322ccb84683"},
+]
+
+[package.dependencies]
+astunparse = {version = ">=1.6.3,<2.0.0", markers = "python_version < \"3.9\""}
+mkdocs = ">=1.4.0,<2.0.0"
+pymdown-extensions = ">=6.3"
+
+[[package]]
 name = "mkdocs-version-annotations"
 version = "1.0.0"
 description = "MkDocs plugin to add custom admonitions for documenting version differences"
@@ -2079,6 +2110,20 @@ files = [
 watchmedo = ["PyYAML (>=3.10)"]
 
 [[package]]
+name = "wheel"
+version = "0.41.0"
+description = "A built-package format for Python"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "wheel-0.41.0-py3-none-any.whl", hash = "sha256:7e9be3bbd0078f6147d82ed9ed957e323e7708f57e134743d2edef3a7b7972a9"},
+    {file = "wheel-0.41.0.tar.gz", hash = "sha256:55a0f0a5a84869bce5ba775abfd9c462e3a6b1b7b7ec69d72c0b83d673a5114d"},
+]
+
+[package.extras]
+test = ["pytest (>=6.0.0)", "setuptools (>=65)"]
+
+[[package]]
 name = "wrapt"
 version = "1.15.0"
 description = "Module for decorators, wrappers and monkey patching."
@@ -2214,4 +2259,4 @@ optionals = ["napalm"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "31acbdd2552dcd4f4f421b8ec8bc0ba4c39aa2bf2b3b03a557ade07c64478520"
+content-hash = "be93681a86ecec82804fec9ab1dcd4f6c8c81cb6b455cd6694ac4d4377239232"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ mkdocs-material = "8.5.8"
 mkdocstrings = "0.22.0"
 mkdocstrings-python = "1.1.2"
 mkdocs-version-annotations = "1.0.0"
+mkdocs-python-classy = "0.1.2"
 
 [tool.black]
 line-length = 120


### PR DESCRIPTION
Add classy docs that will allow one to better visualize the classes in parsers. 

<img width="796" alt="image" src="https://github.com/networktocode/netutils/assets/9260483/e64419d4-ce59-48df-a6cd-2d0a7ec770df">
