### PR TITLE
Duplicate line parsing failiure test cisco_ios

### DIFF
--- a/tests/unit/mock/config/parser/base/cisco_ios/ios_dupline_received.py
+++ b/tests/unit/mock/config/parser/base/cisco_ios/ios_dupline_received.py
@@ -1,0 +1,14 @@
+from netutils.config.parser import ConfigLine
+
+data = [
+    ConfigLine(config_line="hostname dupline", parents=()),
+    ConfigLine(config_line="logging source-interface Loopback0", parents=()),
+    ConfigLine(config_line="logging host 10.10.10.10", parents=()),
+    ConfigLine(config_line="logging host 10.20.10.10 transport udp port 58512", parents=()),
+    ConfigLine(config_line="access-list 93 remark Admin ACL Golden Template Version", parents=()),
+    ConfigLine(config_line="access-list 93 remark Another Remark", parents=()),
+    ConfigLine(config_line="access-list 93 permit 10.0.0.0 0.255.255.255", parents=()),
+    ConfigLine(config_line="access-list 93 permit 192.168.1.0 0.0.255.255", parents=()),
+    ConfigLine(config_line="access-list 93 remark Admin ACL Golden Template Version", parents=()),
+    ConfigLine(config_line="access-list 93 deny any log", parents=()),
+]

--- a/tests/unit/mock/config/parser/base/cisco_ios/ios_dupline_sent.txt
+++ b/tests/unit/mock/config/parser/base/cisco_ios/ios_dupline_sent.txt
@@ -1,0 +1,12 @@
+hostname dupline
+!
+logging source-interface Loopback0
+logging host 10.10.10.10
+logging host 10.20.10.10 transport udp port 58512
+access-list 93 remark Admin ACL Golden Template Version
+access-list 93 remark Another Remark
+access-list 93 permit 10.0.0.0 0.255.255.255
+access-list 93 permit 192.168.1.0 0.0.255.255
+access-list 93 remark Admin ACL Golden Template Version
+access-list 93 deny any log
+!


### PR DESCRIPTION
This PR adds a currently "failing" test that explains/duplicates the issue discribed in GC issue [#704](https://github.com/nautobot/nautobot-app-golden-config/issues/704).

This test should pass once the parser has been fixed.