### PR TITLE
Refactor test, implement dual banner fix

### DIFF
--- a/netutils/config/compliance.py
+++ b/netutils/config/compliance.py
@@ -436,6 +436,10 @@ def section_config(feature: t.Dict[str, t.Union[str, bool, t.List[str]]], device
     os_parser = parser_map[network_os]
     config_parsed = os_parser(device_cfg)
     for line in config_parsed.config_lines:
+        # If multiple banners, line after first banner will be None.
+        # This conditional allows multiple banners in config.
+        if not line.config_line:
+            continue
         if match:
             if line.parents:  # pylint: disable=no-else-continue
                 section_config_list.append(line.config_line)

--- a/tests/unit/mock/config/compliance/feature_compliance/ios_dual_banner_exec_actual.txt
+++ b/tests/unit/mock/config/compliance/feature_compliance/ios_dual_banner_exec_actual.txt
@@ -1,0 +1,14 @@
+hostname dual-banner
+!
+banner exec ^C
+=========
+actual config exec banner
+-========
+^C
+banner motd ^C
+======
+actual config motd banner
+======
+   || ($hostname) ||
+^C
+!

--- a/tests/unit/mock/config/compliance/feature_compliance/ios_dual_banner_exec_feature.py
+++ b/tests/unit/mock/config/compliance/feature_compliance/ios_dual_banner_exec_feature.py
@@ -1,0 +1,2 @@
+feature = {"name": "exec banner", "ordered": False, "section": ["banner exec"]}
+network_os = "cisco_ios"

--- a/tests/unit/mock/config/compliance/feature_compliance/ios_dual_banner_exec_intended.txt
+++ b/tests/unit/mock/config/compliance/feature_compliance/ios_dual_banner_exec_intended.txt
@@ -1,0 +1,14 @@
+hostname dual-banner
+!
+banner exec ^C
+=========
+intended config exec banner
+-========
+^C
+banner motd ^C
+======
+intended config motd banner
+======
+   || ($hostname) ||
+^C
+!

--- a/tests/unit/mock/config/compliance/feature_compliance/ios_dual_banner_exec_received.py
+++ b/tests/unit/mock/config/compliance/feature_compliance/ios_dual_banner_exec_received.py
@@ -1,0 +1,10 @@
+data = {
+    "compliant": False,
+    "missing": "banner exec ^C\n=========\nintended config exec banner\n-========^C",
+    "extra": "banner exec ^C\n=========\nactual config exec banner\n-========^C",
+    "cannot_parse": True,
+    "unordered_compliant": False,
+    "ordered_compliant": False,
+    "actual": "banner exec ^C\n=========\nactual config exec banner\n-========^C",
+    "intended": "banner exec ^C\n=========\nintended config exec banner\n-========^C",
+}

--- a/tests/unit/mock/config/compliance/feature_compliance/ios_dual_banner_feature.py
+++ b/tests/unit/mock/config/compliance/feature_compliance/ios_dual_banner_feature.py
@@ -1,2 +1,2 @@
-feature = {"name": "exec banner", "ordered": False, "section": ["banner exec"]}
+feature = {"name": "exec banner", "ordered": False, "section": ["banner"]}
 network_os = "cisco_ios"

--- a/tests/unit/mock/config/compliance/feature_compliance/ios_dual_banner_motd_actual.txt
+++ b/tests/unit/mock/config/compliance/feature_compliance/ios_dual_banner_motd_actual.txt
@@ -1,0 +1,14 @@
+hostname dual-banner
+!
+banner exec ^C
+=========
+actual config exec banner
+-========
+^C
+banner motd ^C
+======
+actual config motd banner
+======
+   || ($hostname) ||
+^C
+!

--- a/tests/unit/mock/config/compliance/feature_compliance/ios_dual_banner_motd_feature.py
+++ b/tests/unit/mock/config/compliance/feature_compliance/ios_dual_banner_motd_feature.py
@@ -1,0 +1,2 @@
+feature = {"name": "exec banner", "ordered": False, "section": ["banner motd"]}
+network_os = "cisco_ios"

--- a/tests/unit/mock/config/compliance/feature_compliance/ios_dual_banner_motd_intended.txt
+++ b/tests/unit/mock/config/compliance/feature_compliance/ios_dual_banner_motd_intended.txt
@@ -1,0 +1,14 @@
+hostname dual-banner
+!
+banner exec ^C
+=========
+intended config exec banner
+-========
+^C
+banner motd ^C
+======
+intended config motd banner
+======
+   || ($hostname) ||
+^C
+!

--- a/tests/unit/mock/config/compliance/feature_compliance/ios_dual_banner_motd_received.py
+++ b/tests/unit/mock/config/compliance/feature_compliance/ios_dual_banner_motd_received.py
@@ -1,0 +1,10 @@
+data = {
+    "compliant": False,
+    "missing": "banner motd ^C\n======\nintended config motd banner\n======\n   || ($hostname) ||^C",
+    "extra": "banner motd ^C\n======\nactual config motd banner\n======\n   || ($hostname) ||^C",
+    "cannot_parse": True,
+    "unordered_compliant": False,
+    "ordered_compliant": False,
+    "actual": "banner motd ^C\n======\nactual config motd banner\n======\n   || ($hostname) ||^C",
+    "intended": "banner motd ^C\n======\nintended config motd banner\n======\n   || ($hostname) ||^C",
+}

--- a/tests/unit/mock/config/compliance/feature_compliance/ios_dual_banner_received.py
+++ b/tests/unit/mock/config/compliance/feature_compliance/ios_dual_banner_received.py
@@ -1,10 +1,10 @@
 data = {
     "compliant": False,
-    "missing": "banner exec ^C\n=========\nintended config exec banner\n-========^C",
-    "extra": "banner exec ^C\n=========\nactual config exec banner\n-========^C",
+    "missing": "banner exec ^C\n=========\nintended config exec banner\n-========^C\nbanner motd ^C\n======\nintended config motd banner\n======\n   || ($hostname) ||^C",
+    "extra": "banner exec ^C\n=========\nactual config exec banner\n-========^C\nbanner motd ^C\n======\nactual config motd banner\n======\n   || ($hostname) ||^C",
     "cannot_parse": True,
     "unordered_compliant": False,
     "ordered_compliant": False,
-    "actual": "banner exec ^C\n=========\nactual config exec banner\n-========^C",
-    "intended": "banner exec ^C\n=========\nintended config exec banner\n-========^C",
+    "actual": "banner exec ^C\n=========\nactual config exec banner\n-========^C\nbanner motd ^C\n======\nactual config motd banner\n======\n   || ($hostname) ||^C",
+    "intended": "banner exec ^C\n=========\nintended config exec banner\n-========^C\nbanner motd ^C\n======\nintended config motd banner\n======\n   || ($hostname) ||^C",
 }

--- a/tests/unit/mock/config/compliance/feature_compliance/ios_dual_banner_received.py
+++ b/tests/unit/mock/config/compliance/feature_compliance/ios_dual_banner_received.py
@@ -1,10 +1,10 @@
 data = {
     "compliant": False,
-    "missing": "banner exec ^C\n=========\nintended config exec banner\n-========^C\n",
-    "extra": "banner exec ^C\n=========\nactual config exec banner\n-========^C\n",
+    "missing": "banner exec ^C\n=========\nintended config exec banner\n-========^C",
+    "extra": "banner exec ^C\n=========\nactual config exec banner\n-========^C",
     "cannot_parse": True,
     "unordered_compliant": False,
     "ordered_compliant": False,
-    "actual": "hostname dual-banner\n!\nbanner exec ^C\n=========\nactual config exec banner\n-========\n^C\nbanner motd ^C\n======\nactual config motd banner\n======\n   || ($hostname) ||\n^C\n!\n",
-    "intended": "hostname dual-banner\n!\nbanner exec ^C\n=========\nintended config exec banner\n-========\n^C\nbanner motd ^C\n======\nintended config motd banner\n======\n   || ($hostname) ||\n^C\n!",
+    "actual": "banner exec ^C\n=========\nactual config exec banner\n-========^C",
+    "intended": "banner exec ^C\n=========\nintended config exec banner\n-========^C",
 }

--- a/tests/unit/test_compliance.py
+++ b/tests/unit/test_compliance.py
@@ -91,7 +91,12 @@ def test_feature_compliance(_file, get_text_data, get_python_data):
     received_data = get_python_data(truncate_file + "_received.py", "data")
     feature = get_python_data(truncate_file + "_feature.py", "feature")
     nos = get_python_data(truncate_file + "_feature.py", "network_os")
-    assert compliance.feature_compliance(feature, actual_config, intended_config, nos) == received_data
+
+    # Parse feature configs from config files
+    backup_str = compliance.section_config(feature, actual_config, nos)
+    intended_str = compliance.section_config(feature, intended_config, nos)
+
+    assert compliance.feature_compliance(feature, backup_str, intended_str, nos) == received_data
 
 
 def test_incorrect_cfg_type():


### PR DESCRIPTION
Implement handling for multiple banner configurations. ie a configuration file containing both `banner exec` and `banner motd`