### PR TITLE
Improve performance of jinja2_convenience_function by not importing NAPALM when called

### DIFF
--- a/netutils/lib_helpers.py
+++ b/netutils/lib_helpers.py
@@ -5,14 +5,6 @@ import typing as t
 
 from netutils.lib_mapper import NAPALM_LIB_MAPPER
 
-try:
-    from napalm import get_network_driver
-    from napalm.base.exceptions import ModuleImportError
-except ImportError:
-    HAS_NAPALM = False
-else:
-    HAS_NAPALM = True
-
 
 def get_napalm_getters() -> t.Dict[str, t.Dict[str, bool]]:
     """Utility to return a dictionary of napalm getters based on install napalm version.
@@ -31,8 +23,13 @@ def get_napalm_getters() -> t.Dict[str, t.Dict[str, bool]]:
         >>> napalm_getters["eos"]["get_ipv6_neighbors_table"]  # doctest: +SKIP
         >>> False  # doctest: +SKIP
     """
-    if not HAS_NAPALM:
-        raise ImportError("Napalm must be install for this function to operate.")
+    try:
+        # Import NAPALM here at call time, rather than at import time, as importing NAPALM is rather time consuming
+        # pylint: disable=import-outside-toplevel
+        from napalm import get_network_driver
+        from napalm.base.exceptions import ModuleImportError
+    except ImportError as err:
+        raise ImportError("Napalm must be installed for this function to operate.") from err
 
     napalm_dict: t.Dict[str, t.Dict[str, bool]] = {}
     oses = NAPALM_LIB_MAPPER.keys()

--- a/tests/unit/test_lib_helpers.py
+++ b/tests/unit/test_lib_helpers.py
@@ -5,8 +5,8 @@ import pytest
 from netutils.lib_helpers import get_napalm_getters
 
 
-@mock.patch("netutils.lib_helpers.HAS_NAPALM", False)
+@mock.patch.dict("sys.modules", {"napalm": None})
 def test_get_napalm_getters_napalm_not_installed():
     with pytest.raises(ImportError) as exc:
         get_napalm_getters()
-    assert "Napalm must be install for this function to operate." == str(exc.value)
+    assert "Napalm must be installed for this function to operate." == str(exc.value)

--- a/tests/unit/test_lib_helpers_optionals.py
+++ b/tests/unit/test_lib_helpers_optionals.py
@@ -7,7 +7,7 @@ from netutils.lib_helpers import get_napalm_getters
 
 def test_get_napalm_getters_napalm_installed_default():
     pytest.importorskip("napalm")
-    with mock.patch("netutils.lib_helpers.get_network_driver"):
+    with mock.patch("napalm.get_network_driver"):
         napalm_getters = get_napalm_getters()
         assert all(item in napalm_getters.keys() for item in ["asa", "eos", "fortios"])
 


### PR DESCRIPTION
Discovered this while investigating startup performance of the `nautobot-server` command as a part of nautobot/nautobot#4292. I found that the `netutils.utils.jinja2_convenience_function()` function, which is called as a part of Nautobot's startup sequence, turned out to be surprisingly expensive to call, the reason being that `jinja2_convenience_function()` imports (but does not itself call) `netutils.lib_helpers.get_napalm_getters()`, which in turn automatically imports the entire NAPALM library. 

Importing `napalm` takes anywhere from 0.5 to 1 second all by itself, and we don't actually **need** that library imported until we actually *call* `get_napalm_getters()`. My solution here is to simply move the import inside the `get_napalm_getters()` function so that it runs when the function is called, rather then simply when the function is initially imported. This makes `jinja2_convenience_function()` notably faster to call.

(edit on noticing CI failure - Why are there tests that CI includes that aren't run by `invoke tests`? I ran `invoke tests` successfully locally before pushing this branch up. I'll investigate, but that's a bit annoying. :smile: )