### PR TITLE
Add JunOS and Vyatta to HierConfig mappers

### DIFF
--- a/docs/user/lib_mapper/hierconfig.md
+++ b/docs/user/lib_mapper/hierconfig.md
@@ -5,4 +5,6 @@
 | ios | → | cisco_ios |
 | iosxe | → | cisco_xe |
 | iosxr | → | cisco_xr |
+| junos | → | juniper_junos |
 | nxos | → | cisco_nxos |
+| vyos | → | brocade_vyos |

--- a/docs/user/lib_mapper/hierconfig_reverse.md
+++ b/docs/user/lib_mapper/hierconfig_reverse.md
@@ -1,8 +1,10 @@
 | NORMALIZED | | HIERCONFIG |
 | ---------- | -- | ------ |
 | arista_eos | → | eos |
+| brocade_vyos | → | vyos |
 | cisco_ios | → | ios |
 | cisco_nxos | → | nxos |
 | cisco_xe | → | iosxe |
 | cisco_xr | → | iosxr |
+| juniper_junos | → | junos |
 | ruckus_fastiron | → | fastiron |

--- a/netutils/lib_mapper.py
+++ b/netutils/lib_mapper.py
@@ -254,7 +254,9 @@ _NTCTEMPLATES_LIB_MAPPER["aruba_aoscx"] = "aruba_aoscx"
 _NTCTEMPLATES_LIB_MAPPER["huawei_vrp"] = "huawei_vrp"
 _NTCTEMPLATES_LIB_MAPPER["vmware_nsxv"] = "vmware_nsxv"
 _NTCTEMPLATES_LIB_MAPPER["watchguard_firebox"] = "watchguard_firebox"
-NTCTEMPLATES_LIB_MAPPER = {key: _NTCTEMPLATES_LIB_MAPPER[key] for key in sorted(_NTCTEMPLATES_LIB_MAPPER)}
+NTCTEMPLATES_LIB_MAPPER = {
+    key: _NTCTEMPLATES_LIB_MAPPER[key] for key in sorted(_NTCTEMPLATES_LIB_MAPPER)
+}
 
 # NAPALM | Normalized
 NAPALM_LIB_MAPPER = {
@@ -499,13 +501,13 @@ SCRAPLI_LIB_MAPPER_REVERSE = {
 # Normalized | HIERCONFIG
 HIERCONFIG_LIB_MAPPER_REVERSE = {
     "arista_eos": "eos",
+    "brocade_vyos": "vyos",
     "cisco_ios": "ios",
     "cisco_nxos": "nxos",
     "cisco_xe": "iosxe",
     "cisco_xr": "iosxr",
     "juniper_junos": "junos",
     "ruckus_fastiron": "fastiron",
-    "brocade_vyos": "vyos",
 }
 
 # Normalized | Netutils Parser

--- a/netutils/lib_mapper.py
+++ b/netutils/lib_mapper.py
@@ -254,7 +254,9 @@ _NTCTEMPLATES_LIB_MAPPER["aruba_aoscx"] = "aruba_aoscx"
 _NTCTEMPLATES_LIB_MAPPER["huawei_vrp"] = "huawei_vrp"
 _NTCTEMPLATES_LIB_MAPPER["vmware_nsxv"] = "vmware_nsxv"
 _NTCTEMPLATES_LIB_MAPPER["watchguard_firebox"] = "watchguard_firebox"
-NTCTEMPLATES_LIB_MAPPER = {key: _NTCTEMPLATES_LIB_MAPPER[key] for key in sorted(_NTCTEMPLATES_LIB_MAPPER)}
+NTCTEMPLATES_LIB_MAPPER = {
+    key: _NTCTEMPLATES_LIB_MAPPER[key] for key in sorted(_NTCTEMPLATES_LIB_MAPPER)
+}
 
 # NAPALM | Normalized
 NAPALM_LIB_MAPPER = {
@@ -354,7 +356,9 @@ HIERCONFIG_LIB_MAPPER = {
     "ios": "cisco_ios",
     "iosxe": "cisco_xe",
     "iosxr": "cisco_xr",
+    "junos": "juniper_junos",
     "nxos": "cisco_nxos",
+    "vyos": "brocade_vyos",
 }
 
 # Netutils Parser | Normalized
@@ -501,7 +505,9 @@ HIERCONFIG_LIB_MAPPER_REVERSE = {
     "cisco_nxos": "nxos",
     "cisco_xe": "iosxe",
     "cisco_xr": "iosxr",
+    "juniper_junos": "junos",
     "ruckus_fastiron": "fastiron",
+    "brocade_vyos": "vyos",
 }
 
 # Normalized | Netutils Parser

--- a/netutils/lib_mapper.py
+++ b/netutils/lib_mapper.py
@@ -254,9 +254,7 @@ _NTCTEMPLATES_LIB_MAPPER["aruba_aoscx"] = "aruba_aoscx"
 _NTCTEMPLATES_LIB_MAPPER["huawei_vrp"] = "huawei_vrp"
 _NTCTEMPLATES_LIB_MAPPER["vmware_nsxv"] = "vmware_nsxv"
 _NTCTEMPLATES_LIB_MAPPER["watchguard_firebox"] = "watchguard_firebox"
-NTCTEMPLATES_LIB_MAPPER = {
-    key: _NTCTEMPLATES_LIB_MAPPER[key] for key in sorted(_NTCTEMPLATES_LIB_MAPPER)
-}
+NTCTEMPLATES_LIB_MAPPER = {key: _NTCTEMPLATES_LIB_MAPPER[key] for key in sorted(_NTCTEMPLATES_LIB_MAPPER)}
 
 # NAPALM | Normalized
 NAPALM_LIB_MAPPER = {


### PR DESCRIPTION
Just updating the hier-config mappings now that Juniper and Vyatta are supported out of the box. Closes #491.