### PR TITLE
Empty banner parsing failiure test cisco_ios

### DIFF
--- a/tests/unit/mock/config/parser/base/cisco_ios/ios_empty_banner_received.py
+++ b/tests/unit/mock/config/parser/base/cisco_ios/ios_empty_banner_received.py
@@ -1,0 +1,3 @@
+from netutils.config.parser import ConfigLine
+
+data = []

--- a/tests/unit/mock/config/parser/base/cisco_ios/ios_empty_banner_sent.txt
+++ b/tests/unit/mock/config/parser/base/cisco_ios/ios_empty_banner_sent.txt
@@ -1,0 +1,7 @@
+hostname emptybanner
+!
+banner motd ^C^C
+!
+line vty 0 4
+ transport ssh
+!


### PR DESCRIPTION
This PR adds a currently "failing" test that explains/duplicates the issue described in netutils issue #502 

This test should pass once the parser has been fixed.