### PR TITLE
More IOS banner related fixes.

### DIFF
--- a/netutils/config/parser.py
+++ b/netutils/config/parser.py
@@ -334,11 +334,10 @@ class BaseSpaceConfigParser(BaseConfigParser):
             elif self.is_banner_start(line):
                 line = self._build_banner(line)  # type: ignore
                 # line can potentially be another banner start therefore we do a secondary check.
-                print(line)
-                if self.is_banner_start(line):  # type: ignore
+                if self.is_banner_start(line):
                     line = self._build_banner(line)  # type: ignore
 
-            self._update_config_lines(line)  # type: ignore
+            self._update_config_lines(line)
         return self.config_lines
 
     @staticmethod

--- a/netutils/config/parser.py
+++ b/netutils/config/parser.py
@@ -556,7 +556,6 @@ class CiscoConfigParser(BaseSpaceConfigParser):
     @staticmethod
     def is_banner_one_line(config_line: str) -> bool:
         """Determine if all banner config is on one line."""
-        print(config_line)
         _, delimeter, banner = config_line.partition("^C")
         # if the banner is the delimeter is a single line empty banner. e.g banner motd ^C^C which ios allows.
         if banner == "^C":

--- a/netutils/config/parser.py
+++ b/netutils/config/parser.py
@@ -1,4 +1,5 @@
 """Parsers for different network operating systems."""
+
 # pylint: disable=no-member,super-with-arguments,invalid-overridden-method,raise-missing-from,invalid-overridden-method,inconsistent-return-statements,super-with-arguments,redefined-argument-from-local,no-else-break,useless-super-delegation,too-many-lines
 
 import re
@@ -95,6 +96,8 @@ class BaseSpaceConfigParser(BaseConfigParser):
             True if line starts banner, else False.
         """
         for banner_start in self.banner_start:
+            if not line:
+                return False
             if line.lstrip().startswith(banner_start):
                 return True
         return False
@@ -330,8 +333,12 @@ class BaseSpaceConfigParser(BaseConfigParser):
                 break
             elif self.is_banner_start(line):
                 line = self._build_banner(line)  # type: ignore
+                # line can potentially be another banner start therefore we do a secondary check.
+                print(line)
+                if self.is_banner_start(line):  # type: ignore
+                    line = self._build_banner(line)  # type: ignore
 
-            self._update_config_lines(line)
+            self._update_config_lines(line)  # type: ignore
         return self.config_lines
 
     @staticmethod
@@ -550,7 +557,11 @@ class CiscoConfigParser(BaseSpaceConfigParser):
     @staticmethod
     def is_banner_one_line(config_line: str) -> bool:
         """Determine if all banner config is on one line."""
+        print(config_line)
         _, delimeter, banner = config_line.partition("^C")
+        # if the banner is the delimeter is a single line empty banner. e.g banner motd ^C^C which ios allows.
+        if banner == "^C":
+            return True
         # Based on NXOS configs, the banner delimeter is ignored until another char is used
         banner_config_start = banner.lstrip(delimeter)
         if delimeter not in banner_config_start:

--- a/tests/unit/mock/config/compliance/feature_compliance/ios_dual_banner_feature.py
+++ b/tests/unit/mock/config/compliance/feature_compliance/ios_dual_banner_feature.py
@@ -1,2 +1,2 @@
-feature = {"name": "exec banner", "ordered": False, "section": ["banner"]}
+feature = {"name": "dual banner", "ordered": False, "section": ["banner"]}
 network_os = "cisco_ios"

--- a/tests/unit/mock/config/compliance/feature_compliance/ios_dual_banner_motd_feature.py
+++ b/tests/unit/mock/config/compliance/feature_compliance/ios_dual_banner_motd_feature.py
@@ -1,2 +1,2 @@
-feature = {"name": "exec banner", "ordered": False, "section": ["banner motd"]}
+feature = {"name": "motd banner", "ordered": False, "section": ["banner motd"]}
 network_os = "cisco_ios"

--- a/tests/unit/mock/config/compliance/feature_compliance/ios_empty_banner_actual.txt
+++ b/tests/unit/mock/config/compliance/feature_compliance/ios_empty_banner_actual.txt
@@ -1,0 +1,7 @@
+hostname emptybanner
+!
+banner motd ^C^C
+!
+line vty 0 4
+ transport ssh
+!

--- a/tests/unit/mock/config/compliance/feature_compliance/ios_empty_banner_feature.py
+++ b/tests/unit/mock/config/compliance/feature_compliance/ios_empty_banner_feature.py
@@ -1,0 +1,2 @@
+feature = {"name": "banner", "ordered": False, "section": ["banner"]}
+network_os = "cisco_ios"

--- a/tests/unit/mock/config/compliance/feature_compliance/ios_empty_banner_intended.txt
+++ b/tests/unit/mock/config/compliance/feature_compliance/ios_empty_banner_intended.txt
@@ -1,0 +1,9 @@
+hostname emptybanner
+!
+banner motd ^C
+actual banner example
+^C
+!
+line vty 0 4
+ transport ssh
+!

--- a/tests/unit/mock/config/compliance/feature_compliance/ios_empty_banner_received.py
+++ b/tests/unit/mock/config/compliance/feature_compliance/ios_empty_banner_received.py
@@ -1,0 +1,10 @@
+data = {
+    "actual": "banner motd ^C^C",
+    "cannot_parse": True,
+    "compliant": False,
+    "extra": "banner motd ^C^C",
+    "intended": "banner motd ^C\n" "actual banner example^C",
+    "missing": "banner motd ^C\n" "actual banner example^C",
+    "ordered_compliant": False,
+    "unordered_compliant": False,
+}

--- a/tests/unit/mock/config/parser/base/cisco_ios/ios_dual_banner_received.py
+++ b/tests/unit/mock/config/parser/base/cisco_ios/ios_dual_banner_received.py
@@ -1,0 +1,12 @@
+from netutils.config.parser import ConfigLine
+
+data = [
+    ConfigLine(config_line="hostname dual-banner", parents=()),
+    ConfigLine(config_line="banner exec ^C", parents=()),
+    ConfigLine(config_line="=========\nintended config exec banner\n-========^C", parents=("banner exec ^C",)),
+    ConfigLine(config_line="banner motd ^C", parents=()),
+    ConfigLine(
+        config_line="======\nintended config motd banner\n======\n   || ($hostname) ||^C", parents=("banner motd ^C",)
+    ),
+    ConfigLine(config_line=None, parents=()),
+]

--- a/tests/unit/mock/config/parser/base/cisco_ios/ios_dual_banner_sent.txt
+++ b/tests/unit/mock/config/parser/base/cisco_ios/ios_dual_banner_sent.txt
@@ -1,0 +1,14 @@
+hostname dual-banner
+!
+banner exec ^C
+=========
+intended config exec banner
+-========
+^C
+banner motd ^C
+======
+intended config motd banner
+======
+   || ($hostname) ||
+^C
+!

--- a/tests/unit/mock/config/parser/base/cisco_ios/ios_empty_banner_received.py
+++ b/tests/unit/mock/config/parser/base/cisco_ios/ios_empty_banner_received.py
@@ -1,0 +1,8 @@
+from netutils.config.parser import ConfigLine
+
+data = [
+    ConfigLine(config_line="hostname emptybanner", parents=()),
+    ConfigLine(config_line="banner motd ^C^C", parents=()),
+    ConfigLine(config_line="line vty 0 4", parents=()),
+    ConfigLine(config_line=" transport ssh", parents=("line vty 0 4",)),
+]

--- a/tests/unit/mock/config/parser/base/cisco_ios/ios_empty_banner_sent.txt
+++ b/tests/unit/mock/config/parser/base/cisco_ios/ios_empty_banner_sent.txt
@@ -1,0 +1,7 @@
+hostname emptybanner
+!
+banner motd ^C^C
+!
+line vty 0 4
+ transport ssh
+!


### PR DESCRIPTION
Dual banners were still not getting parsed properly. They were able to be compliance checked based on #456 , this addresses the parsing of dual banners, and also fixes #502 .