### PR TITLE
Add Mappings for DNA Center

### DIFF
--- a/development_scripts.py
+++ b/development_scripts.py
@@ -71,6 +71,18 @@ MAPPER = {
             "_dict": lib_mapper.CAPIRCA_LIB_MAPPER_REVERSE,
             "_file": "docs/user/lib_mapper/capirca_reverse.md",
         },
+        "dna_center": {
+            "header_src": "DNA_CENTER",
+            "header_dst": "NORMALIZED",
+            "_dict": lib_mapper.DNA_CENTER_LIB_MAPPER,
+            "_file": "docs/user/lib_mapper/dna_center.md",
+        },
+        "dna_center_reverse": {
+            "header_src": "NORMALIZED",
+            "header_dst": "DNA_CENTER",
+            "_dict": lib_mapper.DNA_CENTER_LIB_MAPPER_REVERSE,
+            "_file": "docs/user/lib_mapper/dna_center.md",
+        },
         "forwardnetworks": {
             "header_src": "FORWARDNETWORKS",
             "header_dst": "NORMALIZED",

--- a/development_scripts.py
+++ b/development_scripts.py
@@ -81,7 +81,7 @@ MAPPER = {
             "header_src": "NORMALIZED",
             "header_dst": "DNA_CENTER",
             "_dict": lib_mapper.DNA_CENTER_LIB_MAPPER_REVERSE,
-            "_file": "docs/user/lib_mapper/dna_center.md",
+            "_file": "docs/user/lib_mapper/dna_center_reverse.md",
         },
         "forwardnetworks": {
             "header_src": "FORWARDNETWORKS",

--- a/docs/user/lib_mapper/dna_center.md
+++ b/docs/user/lib_mapper/dna_center.md
@@ -1,0 +1,5 @@
+| NORMALIZED | | DNA_CENTER |
+| ---------- | -- | ------ |
+| cisco_ios | → | IOS |
+| cisco_nxos | → | NX-OS |
+| cisco_xr | → | IOS-XR |

--- a/docs/user/lib_mapper/dna_center.md
+++ b/docs/user/lib_mapper/dna_center.md
@@ -1,5 +1,6 @@
-| NORMALIZED | | DNA_CENTER |
+| DNA_CENTER | | NORMALIZED |
 | ---------- | -- | ------ |
-| cisco_ios | → | IOS |
-| cisco_nxos | → | NX-OS |
-| cisco_xr | → | IOS-XR |
+| IOS | → | cisco_ios |
+| IOS-XE | → | cisco_ios |
+| IOS-XR | → | cisco_xr |
+| NX-OS | → | cisco_nxos |

--- a/docs/user/lib_mapper/dna_center_reverse.md
+++ b/docs/user/lib_mapper/dna_center_reverse.md
@@ -1,0 +1,5 @@
+| NORMALIZED | | DNA_CENTER |
+| ---------- | -- | ------ |
+| cisco_ios | → | IOS |
+| cisco_nxos | → | NX-OS |
+| cisco_xr | → | IOS-XR |

--- a/netutils/lib_mapper.py
+++ b/netutils/lib_mapper.py
@@ -124,6 +124,22 @@ CAPIRCA_LIB_MAPPER_REVERSE: t.Dict[str, str] = {
     "windows": "windows",
 }
 
+# DNA Center | Normalized
+DNA_CENTER_LIB_MAPPER = {
+    "IOS": "cisco_ios",
+    "IOS-XE": "cisco_ios",
+    "NX-OS": "cisco_nxos",
+    "IOS-XR": "cisco_xr",
+}
+
+# DNA Center | Normalized
+DNA_CENTER_LIB_MAPPER_REVERSE = {
+    "cisco_ios": "IOS",
+    "cisco_xe": "IOS-XE",
+    "cisco_nxos": "NX-OS",
+    "cisco_xr": "IOS-XR",
+}
+
 # Normalized | Netmiko
 NETMIKO_LIB_MAPPER: t.Dict[str, str] = {
     "a10": "a10",

--- a/netutils/lib_mapper.py
+++ b/netutils/lib_mapper.py
@@ -132,10 +132,9 @@ DNA_CENTER_LIB_MAPPER = {
     "IOS-XR": "cisco_xr",
 }
 
-# DNA Center | Normalized
+# Normalized | DNA Center
 DNA_CENTER_LIB_MAPPER_REVERSE = {
     "cisco_ios": "IOS",
-    "cisco_xe": "IOS-XE",
     "cisco_nxos": "NX-OS",
     "cisco_xr": "IOS-XR",
 }


### PR DESCRIPTION
This PR is to add the forward and reverse mappings for DNA Center. I'm a bit unsure how to handle IOS-XE for the reverse though as you can't have two `cisco_ios` keys so I changed the one for XE to be `cisco_xe`. I'd match it in the forward but the XE library mapping in Nautobot is missing some essential bits for IOS-XE.