### PR TITLE
Extend ip_network extension to support method calls with kwargs

### DIFF
--- a/netutils/ip.py
+++ b/netutils/ip.py
@@ -66,7 +66,7 @@ def ipaddress_network(ip: str, attr: str, **kwargs: t.Any) -> t.Any:
     Args:
         ip: IP network str compliant with ipaddress.ip_network inputs.
         attr: An attribute in string dotted format.
-        kwargs: If called a method allows for passing kwargs to resulting method call.
+        kwargs: Keyword arguments to pass along to the given method of ipaddress.ip_network.
 
     Returns:
         Returns the value provided by the ipaddress.ip_network attribute provided.

--- a/tests/unit/test_ip.py
+++ b/tests/unit/test_ip.py
@@ -668,9 +668,11 @@ def test_ipaddress_interface(data):
 def test_ipaddress_network(data):
     assert ip.ipaddress_network(**data["sent"]) == data["received"]
 
+
 @pytest.mark.parametrize("data", IP_NETWORK_WITH_KWARGS)
 def test_ipaddress_network_with_kwargs(data):
     assert str(list(ip.ipaddress_network(**data["sent"]))) == data["received"]
+
 
 @pytest.mark.parametrize("data", IS_CLASSFUL)
 def test_is_classful(data):

--- a/tests/unit/test_ip.py
+++ b/tests/unit/test_ip.py
@@ -43,6 +43,17 @@ IP_INTERFACE = [
     },
 ]
 
+IP_NETWORK_WITH_KWARGS = [
+    {
+        "sent": {"ip": "10.1.1.0/28", "attr": "subnets", "new_prefix": 30},
+        "received": "[IPv4Network('10.1.1.0/30'), IPv4Network('10.1.1.4/30'), IPv4Network('10.1.1.8/30'), IPv4Network('10.1.1.12/30')]",
+    },
+    {
+        "sent": {"ip": "10.1.1.0/28", "attr": "subnets"},
+        "received": "[IPv4Network('10.1.1.0/29'), IPv4Network('10.1.1.8/29')]",
+    },
+]
+
 IP_NETWORK = [
     {
         "sent": {"ip": "10.1.1.0/24", "attr": "hostmask.__str__"},
@@ -657,6 +668,9 @@ def test_ipaddress_interface(data):
 def test_ipaddress_network(data):
     assert ip.ipaddress_network(**data["sent"]) == data["received"]
 
+@pytest.mark.parametrize("data", IP_NETWORK_WITH_KWARGS)
+def test_ipaddress_network_with_kwargs(data):
+    assert str(list(ip.ipaddress_network(**data["sent"]))) == data["received"]
 
 @pytest.mark.parametrize("data", IS_CLASSFUL)
 def test_is_classful(data):


### PR DESCRIPTION
ip_network has additional method calls that support additional kwargs to be passed in.  This adds that support.  For clarity, ip_address and ip_interface don't have these, so the extension is only on ip_network.

Example
```python
>>> list(ipaddress_network('192.168.1.0/28', 'subnets', new_prefix=30))
[IPv4Network('192.168.1.0/30'), IPv4Network('192.168.1.4/30'), IPv4Network('192.168.1.8/30'), IPv4Network('192.168.1.12/30')]
```

or jinja2

```python
from jinja2 import Environment, select_autoescape
from netutils.utils import jinja2_convenience_function

template_string = """
Example:
{% for sub in "192.168.1.0/28" | ipaddress_network('subnets', new_prefix=30) | list %}
{{ sub.with_netmask }}
{% endfor %}
"""

env = Environment(
    autoescape=select_autoescape()
)
env.filters.update(jinja2_convenience_function())
template = env.from_string(template_string)
result = template.render()
print(result)

```

```
>>> print(result)

Example:

192.168.1.0/255.255.255.252

192.168.1.4/255.255.255.252

192.168.1.8/255.255.255.252

192.168.1.12/255.255.255.252

```