### PR TITLE
fix ntctemplate reverse mapping for cisco xe

### DIFF
--- a/docs/user/lib_mapper/ntctemplates.md
+++ b/docs/user/lib_mapper/ntctemplates.md
@@ -33,7 +33,7 @@
 | cisco_s300 | → | cisco_s300 |
 | cisco_tp | → | cisco_tp |
 | cisco_wlc | → | cisco_wlc |
-| cisco_xe | → | cisco_ios |
+| cisco_xe | → | cisco_xe |
 | cisco_xr | → | cisco_xr |
 | cloudgenix_ion | → | cloudgenix_ion |
 | coriant | → | coriant |

--- a/docs/user/lib_mapper/ntctemplates_reverse.md
+++ b/docs/user/lib_mapper/ntctemplates_reverse.md
@@ -33,6 +33,7 @@
 | cisco_s300 | → | cisco_s300 |
 | cisco_tp | → | cisco_tp |
 | cisco_wlc | → | cisco_wlc |
+| cisco_xe | → | cisco_ios |
 | cisco_xr | → | cisco_xr |
 | cloudgenix_ion | → | cloudgenix_ion |
 | coriant | → | coriant |

--- a/netutils/lib_mapper.py
+++ b/netutils/lib_mapper.py
@@ -260,7 +260,6 @@ NETMIKO_LIB_MAPPER_REVERSE: t.Dict[str, str] = {
 # ntc templates is primarily based on netmiko, so a copy is in order
 _NTCTEMPLATES_LIB_MAPPER = copy.deepcopy(NETMIKO_LIB_MAPPER)
 _NTCTEMPLATES_LIB_MAPPER["aruba_aoscx"] = "aruba_aoscx"
-_NTCTEMPLATES_LIB_MAPPER["cisco_xe"] = "cisco_ios"  # no reverse
 _NTCTEMPLATES_LIB_MAPPER["huawei_vrp"] = "huawei_vrp"
 _NTCTEMPLATES_LIB_MAPPER["vmware_nsxv"] = "vmware_nsxv"
 _NTCTEMPLATES_LIB_MAPPER["watchguard_firebox"] = "watchguard_firebox"
@@ -270,12 +269,13 @@ NTCTEMPLATES_LIB_MAPPER: t.Dict[str, str] = {
     key: _NTCTEMPLATES_LIB_MAPPER[key] for key in sorted(_NTCTEMPLATES_LIB_MAPPER)
 }
 # Normalized | NTCTemplates
-NTCTEMPLATES_LIB_MAPPER_REVERSE: t.Dict[str, str] = {
-    value: key
-    for key, value in NTCTEMPLATES_LIB_MAPPER.items()
-    if key not in ["f5_ltm", "f5_tmsh", "f5_linux", "cisco_xe"]
+_NTCTEMPLATES_LIB_MAPPER_REVERSE: t.Dict[str, str] = {
+    value: key for key, value in NTCTEMPLATES_LIB_MAPPER.items() if key not in ["f5_ltm", "f5_tmsh", "f5_linux"]
 }
 
+_NTCTEMPLATES_LIB_MAPPER_REVERSE["cisco_xe"] = "cisco_ios"  # only reverse
+
+NTCTEMPLATES_LIB_MAPPER_REVERSE = copy.deepcopy(_NTCTEMPLATES_LIB_MAPPER_REVERSE)
 
 # NAPALM | Normalized
 NAPALM_LIB_MAPPER: t.Dict[str, str] = {

--- a/tests/unit/test_lib_mapper.py
+++ b/tests/unit/test_lib_mapper.py
@@ -64,6 +64,7 @@ def test_lib_mapper_reverse(lib):
         "FORWARDNETWORKS",
         "HIERCONFIG",
         "NETUTILSPARSER",
+        "NTCTEMPLATES",
         "NAPALM",
         "PYATS",
         "PYNTC",
@@ -85,6 +86,14 @@ def test_lib_mapper_reverse(lib):
     mapper = dict((v, k) for k, v in _mapper.items())
 
     assert mapper == rev_mapper
+
+
+def test_lib_mapper_ntctemplates_reverse_only():
+    """Cisco XE is the only one that has a reverse ONLY mapping."""
+    assert lib_mapper.NTCTEMPLATES_LIB_MAPPER_REVERSE["cisco_xe"] == "cisco_ios"
+    assert lib_mapper.NTCTEMPLATES_LIB_MAPPER_REVERSE["cisco_ios"] == "cisco_ios"
+    assert lib_mapper.NTCTEMPLATES_LIB_MAPPER["cisco_ios"] == "cisco_ios"
+    assert lib_mapper.NTCTEMPLATES_LIB_MAPPER["cisco_xe"] == "cisco_xe"
 
 
 @pytest.mark.parametrize("lib", LIBRARIES)


### PR DESCRIPTION
This [solution](https://github.com/networktocode/netutils/pull/553) was backwards/wrong.  Fixing the reverse mapping and setting this one as a "only reverse" option

