### PR TITLE
Use legacycrypt where crypt isn't available

### DIFF
--- a/netutils/password.py
+++ b/netutils/password.py
@@ -1,7 +1,5 @@
 """Functions for working with Passwords."""
 
-# TODO: Swap out crypt prior to py3.13
-import crypt  # pylint: disable=deprecated-module
 import random
 import secrets
 import string
@@ -247,6 +245,13 @@ def encrypt_cisco_type5(unencrypted_password: str, salt: t.Optional[str] = None,
         '$1$MHkb$v2MFmDkQX66TTxLkFF50K/'
         >>>
     """
+    try:
+        import crypt  # pylint: disable=deprecated-module
+    except ModuleNotFoundError:
+        try:
+            import legacycrypt as crypt
+        except ModuleNotFoundError:
+            raise ValueError("Crypt module not available")
     if not salt:
         salt = "".join(secrets.choice(ALPHABET) for _ in range(salt_len))
     elif not set(salt) <= set(ALPHABET):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ napalm = {version = "^4.0.0", optional = true}
 jsonschema = {version = "^4.17.3", optional = true}
 
 [tool.poetry.extras]
-optionals = ["jsonschema", "napalm"]
+optionals = ["jsonschema", "napalm", "legacycrypt"]
 
 [tool.poetry.group.dev.dependencies]
 bandit = "*"


### PR DESCRIPTION
Since Python 3.13 has removed the crypt module, add legacycrypt to the requirements if we're using that version of Python, importing it if the crypt module isn't found.

Fixes #594