### PR TITLE
add cisco_wlc_ssh mapping to ntctemplates lib mapper

### DIFF
--- a/docs/user/lib_mapper/ntctemplates.md
+++ b/docs/user/lib_mapper/ntctemplates.md
@@ -33,6 +33,7 @@
 | cisco_s300 | → | cisco_s300 |
 | cisco_tp | → | cisco_tp |
 | cisco_wlc | → | cisco_wlc |
+| cisco_wlc_ssh | → | cisco_wlc |
 | cisco_xe | → | cisco_xe |
 | cisco_xr | → | cisco_xr |
 | cloudgenix_ion | → | cloudgenix_ion |

--- a/docs/user/lib_mapper/ntctemplates_reverse.md
+++ b/docs/user/lib_mapper/ntctemplates_reverse.md
@@ -32,7 +32,7 @@
 | cisco_nxos | → | cisco_nxos |
 | cisco_s300 | → | cisco_s300 |
 | cisco_tp | → | cisco_tp |
-| cisco_wlc | → | cisco_wlc |
+| cisco_wlc | → | cisco_wlc_ssh |
 | cisco_xe | → | cisco_ios |
 | cisco_xr | → | cisco_xr |
 | cloudgenix_ion | → | cloudgenix_ion |

--- a/netutils/lib_mapper.py
+++ b/netutils/lib_mapper.py
@@ -261,6 +261,7 @@ NETMIKO_LIB_MAPPER_REVERSE: t.Dict[str, str] = {
 # ntc templates is primarily based on netmiko, so a copy is in order
 _NTCTEMPLATES_LIB_MAPPER = copy.deepcopy(NETMIKO_LIB_MAPPER)
 _NTCTEMPLATES_LIB_MAPPER["aruba_aoscx"] = "aruba_aoscx"
+_NTCTEMPLATES_LIB_MAPPER["cisco_wlc_ssh"] = "cisco_wlc"
 _NTCTEMPLATES_LIB_MAPPER["huawei_vrp"] = "huawei_vrp"
 _NTCTEMPLATES_LIB_MAPPER["vmware_nsxv"] = "vmware_nsxv"
 _NTCTEMPLATES_LIB_MAPPER["watchguard_firebox"] = "watchguard_firebox"


### PR DESCRIPTION
Fixes https://github.com/networktocode/netutils/issues/528 

> Need to fix cisco_wlc to map to cisco_wlc_ssh for ntc-templates.