### PR TITLE
Add Additional SROS Tests

### DIFF
--- a/tests/unit/mock/config/compliance/section/nokia_sros/sros_basic_feature.py
+++ b/tests/unit/mock/config/compliance/section/nokia_sros/sros_basic_feature.py
@@ -1,0 +1,1 @@
+feature = {"name": "System Configuration", "ordered": False, "section": ["System Configuration"]}

--- a/tests/unit/mock/config/compliance/section/nokia_sros/sros_basic_received.txt
+++ b/tests/unit/mock/config/compliance/section/nokia_sros/sros_basic_received.txt
@@ -1,0 +1,14 @@
+System Configuration
+    system
+        name "sros-r1"
+        netconf
+            auto-config-save
+            no shutdown
+        exit
+        time
+            sntp
+                shutdown
+            exit
+            zone UTC
+        exit
+    exit

--- a/tests/unit/mock/config/compliance/section/nokia_sros/sros_basic_sent.txt
+++ b/tests/unit/mock/config/compliance/section/nokia_sros/sros_basic_sent.txt
@@ -1,0 +1,18 @@
+exit all
+configure
+#--------------------------------------------------
+echo "System Configuration"
+#--------------------------------------------------
+    system
+        name "sros-r1"
+        netconf
+            auto-config-save
+            no shutdown
+        exit
+        time
+            sntp
+                shutdown
+            exit
+            zone UTC
+        exit
+    exit

--- a/tests/unit/mock/config/compliance/section/nokia_sros/sros_full_feature.py
+++ b/tests/unit/mock/config/compliance/section/nokia_sros/sros_full_feature.py
@@ -1,0 +1,1 @@
+feature = {"name": "radius", "ordered": False, "section": ["configure system security radius "]}

--- a/tests/unit/mock/config/compliance/section/nokia_sros/sros_full_received.txt
+++ b/tests/unit/mock/config/compliance/section/nokia_sros/sros_full_received.txt
@@ -1,0 +1,5 @@
+configure system security radius operator-policy name:RADIUS
+configure system security radius auth-server RADIUS1 router-instance base ip-address 1.2.3.4 secret encrypted:al:d6:2f:b8:0a:85:7e:f1:f8:5a:bd:8f:55:83:l3:ad
+configure system security radius acc-server RADIUS1 router-instance base ip-address 5.6.7.8 secret encrypted:su:f2:1e:c5:5a:65:1b:d1:e0:2f:db:0a:71:56:f6:bf
+configure system security radius policy RADIUS nas-id PKB7J0VH77 nas-ip-address 126.65.111.173
+configure system security radius policy RADIUS servers 1 auth-server name:RADIUS1 auth-router-inst base priority 1 acc-server name:RADIUS1

--- a/tests/unit/mock/config/compliance/section/nokia_sros/sros_full_sent.txt
+++ b/tests/unit/mock/config/compliance/section/nokia_sros/sros_full_sent.txt
@@ -1,0 +1,8 @@
+configure system security login-banner "\r\n***** DO NOT LOGIN UNLESS AUTHORIZED!!! *****\r\n"
+configure system security snmp community TEST host-address 20.81.6.14/28
+configure system security radius operator-policy name:RADIUS
+configure system security radius auth-server RADIUS1 router-instance base ip-address 1.2.3.4 secret encrypted:al:d6:2f:b8:0a:85:7e:f1:f8:5a:bd:8f:55:83:l3:ad
+configure system security radius acc-server RADIUS1 router-instance base ip-address 5.6.7.8 secret encrypted:su:f2:1e:c5:5a:65:1b:d1:e0:2f:db:0a:71:56:f6:bf
+configure system security radius policy RADIUS nas-id PKB7J0VH77 nas-ip-address 126.65.111.173
+configure system security radius policy RADIUS servers 1 auth-server name:RADIUS1 auth-router-inst base priority 1 acc-server name:RADIUS1
+configure system security domain authenticator authenticator radius:RADIUS


### PR DESCRIPTION
I noticed that we were missing some tests for Nokia SROS platform. Specifically confirming that the parser will return the expected section specified in the feature/rule.

I've provided both the configure and indented formats of SROS configs just to have on the record that both work.