### PR TITLE
Fix Palo set format config parsing if curly brace exists

### DIFF
--- a/netutils/config/parser.py
+++ b/netutils/config/parser.py
@@ -1550,7 +1550,7 @@ class PaloAltoNetworksConfigParser(BaseSpaceConfigParser):
 
         # if config is in palo brace format, convert to set
         if self.config_lines_only is not None:
-            for line in self.config_lines_only:
+            for line in self.config_lines_only.split("\n"):
                 if line.endswith("{"):
                     _needs_conversion = True
         if _needs_conversion:

--- a/netutils/config/parser.py
+++ b/netutils/config/parser.py
@@ -1550,7 +1550,7 @@ class PaloAltoNetworksConfigParser(BaseSpaceConfigParser):
 
         # if config is in palo brace format, convert to set
         if self.config_lines_only is not None:
-            for line in self.config_lines_only.split("\n"):
+            for line in self.config_lines_only.splitlines():
                 if line.endswith("{"):
                     _needs_conversion = True
         if _needs_conversion:

--- a/tests/unit/mock/config/parser/base/paloalto_panos/panos_basic_set_received.py
+++ b/tests/unit/mock/config/parser/base/paloalto_panos/panos_basic_set_received.py
@@ -1,0 +1,48 @@
+from netutils.config.parser import ConfigLine
+
+data = [
+    ConfigLine(
+        config_line="set mgt-config users admin phash *",
+        parents=(),
+    ),
+    ConfigLine(
+        config_line="set mgt-config users admin permissions role-based superuser yes",
+        parents=(),
+    ),
+    ConfigLine(
+        config_line="set mgt-config users admin public-key thisisasuperduperlongbase64encodedstring",
+        parents=(),
+    ),
+    ConfigLine(
+        config_line="set mgt-config users panadmin permissions role-based superuser yes",
+        parents=(),
+    ),
+    ConfigLine(
+        config_line="set mgt-config users panadmin phash passwordhash",
+        parents=(),
+    ),
+    ConfigLine(
+        config_line="set deviceconfig system hostname firewall1",
+        parents=(),
+    ),
+    ConfigLine(
+        config_line='set deviceconfig system login-banner "',
+        parents=(),
+    ),
+    ConfigLine(
+        config_line="************************************************************************\n*                        firewall1.example.com                       *                         [PROD VM500  firewalls]\n************************************************************************\n*                               WARNING                                *\n*   Unauthorized access to this device or devices attached to          *\n*   or accessible from this network is strictly prohibited.            *\n*   Possession of passwords or devices enabling access to this         *\n*   device or devices does not constitute authorization. Unauthorized  *\n*   access will be prosecuted to the fullest extent of the law.        *\n*                                                                      *\n************************************************************************^C",
+        parents=('set deviceconfig system login-banner "',),
+    ),
+    ConfigLine(
+        config_line="set deviceconfig system panorama local-panorama panorama-server 10.0.0.1",
+        parents=(),
+    ),
+    ConfigLine(
+        config_line="set deviceconfig system panorama local-panorama panorama-server-2 10.0.0.2",
+        parents=(),
+    ),
+    ConfigLine(
+        config_line='set network interface ethernet ethernet1/15 comment "test curly braces {REMOTE DEVICE}, {REMOTE PORT}"',
+        parents=(),
+    ),
+]

--- a/tests/unit/mock/config/parser/base/paloalto_panos/panos_basic_set_sent.txt
+++ b/tests/unit/mock/config/parser/base/paloalto_panos/panos_basic_set_sent.txt
@@ -1,0 +1,22 @@
+set mgt-config users admin phash *
+set mgt-config users admin permissions role-based superuser yes
+set mgt-config users admin public-key thisisasuperduperlongbase64encodedstring
+set mgt-config users panadmin permissions role-based superuser yes
+set mgt-config users panadmin phash passwordhash
+set deviceconfig system hostname firewall1
+set deviceconfig system login-banner "
+************************************************************************
+*                        firewall1.example.com                       *                         [PROD VM500  firewalls]
+************************************************************************
+*                               WARNING                                *
+*   Unauthorized access to this device or devices attached to          *
+*   or accessible from this network is strictly prohibited.            *
+*   Possession of passwords or devices enabling access to this         *
+*   device or devices does not constitute authorization. Unauthorized  *
+*   access will be prosecuted to the fullest extent of the law.        *
+*                                                                      *
+************************************************************************"
+
+set deviceconfig system panorama local-panorama panorama-server 10.0.0.1
+set deviceconfig system panorama local-panorama panorama-server-2 10.0.0.2
+set network interface ethernet ethernet1/15 comment "test curly braces {REMOTE DEVICE}, {REMOTE PORT}"


### PR DESCRIPTION
Fixes #650

When checking if file needs conversion, it needs to loop over each line. Previously due to the config string being one long string rather than a list, it was looping over each character, so a curly brace found would cause it to try and convert from brace format to set format.

Added new test for this scenario.