### PR TITLE
CiscoIOSXRConfigParser finding delimiter when banner is at the end of a config

### DIFF
--- a/netutils/config/parser.py
+++ b/netutils/config/parser.py
@@ -1399,6 +1399,8 @@ class IOSXRConfigParser(CiscoConfigParser):
             if line is None:
                 break
             elif self.is_banner_start(line):
+                if not self.delimiter:
+                    self.set_delimiter(line)
                 line = self._build_banner(line)  # type: ignore
 
             self._update_config_lines(line)

--- a/netutils/config/parser.py
+++ b/netutils/config/parser.py
@@ -195,9 +195,7 @@ class BaseSpaceConfigParser(BaseConfigParser):
                 previous_parent = self._current_parents[-deindent_level]
                 previous_indent = self.get_leading_space_count(previous_parent)
         except IndexError:
-            raise IndexError(
-                f"\nValidate the first line does not begin with a space\n{line}\n"
-            )
+            raise IndexError(f"\nValidate the first line does not begin with a space\n{line}\n")
         parents = self._current_parents[:-deindent_level] or (self._current_parents[0],)
         return parents
 
@@ -420,9 +418,7 @@ class BaseSpaceConfigParser(BaseConfigParser):
         for cfg_line in self.build_config_relationship():
             parents = cfg_line.parents[0] if cfg_line.parents else None
             if parents in potential_parents and self._match_type_check(
-                parents,
-                parent_pattern,
-                match_type,  # type: ignore[arg-type]
+                parents, parent_pattern, match_type  # type: ignore[arg-type]
             ):
                 config.append(cfg_line.config_line)
         return config
@@ -440,11 +436,7 @@ class BaseBraceConfigParser(BaseConfigParser):  # pylint: disable=abstract-metho
         Returns:
             The non-space lines from ``config``.
         """
-        config_lines = [
-            line.rstrip()
-            for line in self.config.splitlines()
-            if line and not line.isspace()
-        ]
+        config_lines = [line.rstrip() for line in self.config.splitlines() if line and not line.isspace()]
         return "\n".join(config_lines)
 
     def build_config_relationship(self) -> t.List[ConfigLine]:
@@ -522,9 +514,7 @@ class BaseBraceConfigParser(BaseConfigParser):  # pylint: disable=abstract-metho
         for line in self.generator_config:
             multiline_config.append(line)
             if line.lstrip() == delimiter:
-                multiline_entry = ConfigLine(
-                    "\n".join(multiline_config), self._current_parents
-                )
+                multiline_entry = ConfigLine("\n".join(multiline_config), self._current_parents)
                 self.config_lines.append(multiline_entry)
                 self._current_parents = self._current_parents[:-1]
                 return multiline_entry
@@ -534,9 +524,7 @@ class BaseBraceConfigParser(BaseConfigParser):  # pylint: disable=abstract-metho
 class CiscoConfigParser(BaseSpaceConfigParser):
     """Cisco Implementation of ConfigParser Class."""
 
-    regex_banner = re.compile(
-        r"^(banner\s+\S+|\s*vacant-message)\s+(?P<banner_delimiter>\^C|.)"
-    )
+    regex_banner = re.compile(r"^(banner\s+\S+|\s*vacant-message)\s+(?P<banner_delimiter>\^C|.)")
 
     def __init__(self, config: str):
         """Create ConfigParser Object.
@@ -598,9 +586,7 @@ class CiscoConfigParser(BaseSpaceConfigParser):
     def banner_end(self, banner_start_line: str) -> None:
         banner_parsed = self.regex_banner.match(banner_start_line)
         if not banner_parsed:
-            raise ValueError(
-                "There was an error parsing your banner, the end of the banner could not be found"
-            )
+            raise ValueError("There was an error parsing your banner, the end of the banner could not be found")
         self._banner_end = banner_parsed.groupdict()["banner_delimiter"]
 
 
@@ -869,9 +855,7 @@ class F5ConfigParser(BaseBraceConfigParser):
 
         return self.config_lines
 
-    def _build_multiline_single_configuration_line(
-        self, delimiter: str, prev_line: str
-    ) -> t.Optional[ConfigLine]:
+    def _build_multiline_single_configuration_line(self, delimiter: str, prev_line: str) -> t.Optional[ConfigLine]:
         r"""Concatenate Multiline strings between delimiter when newlines causes string to traverse multiple lines.
 
         Args:
@@ -909,9 +893,7 @@ class F5ConfigParser(BaseBraceConfigParser):
         for line in self.generator_config:
             multiline_config.append(line)
             if line.endswith(delimiter):
-                multiline_entry = ConfigLine(
-                    "\n".join(multiline_config), self._current_parents
-                )
+                multiline_entry = ConfigLine("\n".join(multiline_config), self._current_parents)
                 self.config_lines[-1] = multiline_entry
                 self._current_parents = self._current_parents[:-1]
                 return multiline_entry
@@ -1074,9 +1056,7 @@ class FortinetConfigParser(BaseSpaceConfigParser):
         # This will grab everything between quotes after the 'set buffer' sub-command.
         # Its explicitly looking for "\n to end the captured data.  This is to support html
         # data that is supported in Fortinet config with double quotes within the html.
-        pattern = (
-            r"(config system replacemsg.*(\".*\")\n)(\s{4}set\sbuffer\s\"[\S\s]*?\"\n)"
-        )
+        pattern = r"(config system replacemsg.*(\".*\")\n)(\s{4}set\sbuffer\s\"[\S\s]*?\"\n)"
         return re.sub(pattern, r"\1    [\2]\n", config)
 
     @property
@@ -1092,10 +1072,7 @@ class FortinetConfigParser(BaseSpaceConfigParser):
             config_lines = (
                 line.rstrip()
                 for line in self.config.splitlines()
-                if line
-                and not self.is_comment(line)
-                and not line.isspace()
-                and not self.is_end_next(line)
+                if line and not self.is_comment(line) and not line.isspace() and not self.is_end_next(line)
             )
             self._config = "\n".join(config_lines)
         return self._config
@@ -1422,10 +1399,7 @@ class IOSXRConfigParser(CiscoConfigParser):
             if line is None:
                 break
             elif self.is_banner_start(line):
-                if not self.delimiter:
-                    self.set_delimiter(line)
-                line = self._build_banner(line)
-                # type: ignore
+                line = self._build_banner(line)  # type: ignore
 
             self._update_config_lines(line)
         return self.config_lines
@@ -1512,12 +1486,7 @@ class PaloAltoNetworksConfigParser(BaseSpaceConfigParser):
 
     def is_banner_end(self, line: str) -> bool:
         """Determine if end of banner."""
-        if (
-            line.endswith('"')
-            or line.startswith('";')
-            or line.startswith("set")
-            or line.endswith(self.banner_end)
-        ):
+        if line.endswith('"') or line.startswith('";') or line.startswith("set") or line.endswith(self.banner_end):
             return True
         return False
 
@@ -1585,9 +1554,7 @@ class PaloAltoNetworksConfigParser(BaseSpaceConfigParser):
                 if line.endswith("{"):
                     _needs_conversion = True
         if _needs_conversion:
-            converted_config = paloalto_panos_brace_to_set(
-                cfg=self.config, cfg_type="string"
-            )
+            converted_config = paloalto_panos_brace_to_set(cfg=self.config, cfg_type="string")
             list_config = converted_config.splitlines()
             self.generator_config = (line for line in list_config)
 

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -7,9 +7,7 @@ import pytest
 
 from netutils.config import compliance
 
-MOCK_DIR = os.path.join(
-    os.path.dirname(os.path.realpath(__file__)), "mock", "config", "parser"
-)
+MOCK_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "mock", "config", "parser")
 TXT_FILE = "_sent.txt"
 
 base_parameters = []
@@ -20,9 +18,7 @@ for network_os in list(compliance.parser_map.keys()):
         base_parameters.append([_file, network_os])
     for _file in glob.glob(f"{MOCK_DIR}/find_all_children/{network_os}/*{TXT_FILE}"):
         find_all_children_parameters.append([_file, network_os])
-    for _file in glob.glob(
-        f"{MOCK_DIR}/find_children_w_parents/{network_os}/*{TXT_FILE}"
-    ):
+    for _file in glob.glob(f"{MOCK_DIR}/find_children_w_parents/{network_os}/*{TXT_FILE}"):
         find_children_w_parents_parameters.append([_file, network_os])
 
 
@@ -41,32 +37,23 @@ def test_find_all_children(_file, network_os, get_text_data, get_json_data):  # 
     truncate_file = os.path.join(MOCK_DIR, "find_all_children", _file[: -len(TXT_FILE)])
 
     device_cfg = get_text_data(os.path.join(MOCK_DIR, "find_all_children", _file))
-    received_data = get_text_data(
-        os.path.join(MOCK_DIR, "find_all_children", truncate_file + "_received.txt")
-    )
+    received_data = get_text_data(os.path.join(MOCK_DIR, "find_all_children", truncate_file + "_received.txt"))
     kwargs = get_json_data(truncate_file + "_args.json")
     os_parser = compliance.parser_map[network_os]
     assert "\n".join(os_parser(device_cfg).find_all_children(**kwargs)) == received_data
 
 
 @pytest.mark.parametrize("_file, network_os", find_children_w_parents_parameters)
-def test_find_children_w_parents(_file, network_os, get_text_data, get_json_data):  # pylint: disable=redefined-outer-name
-    truncate_file = os.path.join(
-        MOCK_DIR, "find_children_w_parents", _file[: -len(TXT_FILE)]
-    )
+def test_find_children_w_parents(
+    _file, network_os, get_text_data, get_json_data
+):  # pylint: disable=redefined-outer-name
+    truncate_file = os.path.join(MOCK_DIR, "find_children_w_parents", _file[: -len(TXT_FILE)])
 
     device_cfg = get_text_data(os.path.join(MOCK_DIR, "find_children_w_parents", _file))
-    received_data = get_text_data(
-        os.path.join(
-            MOCK_DIR, "find_children_w_parents", truncate_file + "_received.txt"
-        )
-    )
+    received_data = get_text_data(os.path.join(MOCK_DIR, "find_children_w_parents", truncate_file + "_received.txt"))
     kwargs = get_json_data(truncate_file + "_args.json")
     os_parser = compliance.parser_map[network_os]
-    assert (
-        "\n".join(os_parser(device_cfg).find_children_w_parents(**kwargs))
-        == received_data
-    )
+    assert "\n".join(os_parser(device_cfg).find_children_w_parents(**kwargs)) == received_data
 
 
 def test_incorrect_banner_ios():
@@ -91,35 +78,5 @@ def test_duplicate_line():
         "snmp-server community <<REPLACED>> RO SNMP_ACL_RO\n"
         "snmp-server community <<REPLACED>> RW SNMP_ACL_RW\n"
     )
-    with pytest.raises(
-        IndexError, match=r".*This error is likely from a duplicate line detected.*"
-    ):
+    with pytest.raises(IndexError, match=r".*This error is likely from a duplicate line detected.*"):
         compliance.parser_map["cisco_ios"](logging).config_lines  # pylint: disable=expression-not-assigned
-
-
-def test_banner_delimiter_iosxr():
-    banner_cfg = (
-        "banner motd ^This is the first line of a test banner.\n"
-        "This is the second line of a test banner.\n"
-        "This is the third line of a test banner.^\n"
-        "\n"
-        "ntp\n"
-        " server 192.0.2.1\n"
-        " server 192.0.2.2\n"
-    )
-    delimiter = compliance.parser_map["cisco_iosxr"](banner_cfg).delimiter
-    assert delimiter == "^"
-
-
-def test_banner_eof_delimiter_iosxr():
-    banner_cfg = (
-        "ntp\n"
-        " server 192.0.2.1\n"
-        " server 192.0.2.2\n"
-        "\n"
-        "banner motd ^This is the first line of a test banner.\n"
-        "This is the second line of a test banner.\n"
-        "This is the third line of a test banner.^\n"
-    )
-    delimiter = compliance.parser_map["cisco_iosxr"](banner_cfg).delimiter
-    assert delimiter == "^"

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -80,3 +80,31 @@ def test_duplicate_line():
     )
     with pytest.raises(IndexError, match=r".*This error is likely from a duplicate line detected.*"):
         compliance.parser_map["cisco_ios"](logging).config_lines  # pylint: disable=expression-not-assigned
+
+
+def test_banner_delimiter_iosxr():
+    banner_cfg = (
+        "banner motd ^This is the first line of a test banner.\n"
+        "This is the second line of a test banner.\n"
+        "This is the third line of a test banner.^\n"
+        "\n"
+        "ntp\n"
+        " server 192.0.2.1\n"
+        " server 192.0.2.2\n"
+    )
+    delimiter = compliance.parser_map["cisco_iosxr"](banner_cfg).delimiter
+    assert delimiter == "^"
+
+
+def test_banner_eof_delimiter_iosxr():
+    banner_cfg = (
+        "ntp\n"
+        " server 192.0.2.1\n"
+        " server 192.0.2.2\n"
+        "\n"
+        "banner motd ^This is the first line of a test banner.\n"
+        "This is the second line of a test banner.\n"
+        "This is the third line of a test banner.^\n"
+    )
+    delimiter = compliance.parser_map["cisco_iosxr"](banner_cfg).delimiter
+    assert delimiter == "^"

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -7,7 +7,9 @@ import pytest
 
 from netutils.config import compliance
 
-MOCK_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "mock", "config", "parser")
+MOCK_DIR = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)), "mock", "config", "parser"
+)
 TXT_FILE = "_sent.txt"
 
 base_parameters = []
@@ -18,7 +20,9 @@ for network_os in list(compliance.parser_map.keys()):
         base_parameters.append([_file, network_os])
     for _file in glob.glob(f"{MOCK_DIR}/find_all_children/{network_os}/*{TXT_FILE}"):
         find_all_children_parameters.append([_file, network_os])
-    for _file in glob.glob(f"{MOCK_DIR}/find_children_w_parents/{network_os}/*{TXT_FILE}"):
+    for _file in glob.glob(
+        f"{MOCK_DIR}/find_children_w_parents/{network_os}/*{TXT_FILE}"
+    ):
         find_children_w_parents_parameters.append([_file, network_os])
 
 
@@ -37,23 +41,32 @@ def test_find_all_children(_file, network_os, get_text_data, get_json_data):  # 
     truncate_file = os.path.join(MOCK_DIR, "find_all_children", _file[: -len(TXT_FILE)])
 
     device_cfg = get_text_data(os.path.join(MOCK_DIR, "find_all_children", _file))
-    received_data = get_text_data(os.path.join(MOCK_DIR, "find_all_children", truncate_file + "_received.txt"))
+    received_data = get_text_data(
+        os.path.join(MOCK_DIR, "find_all_children", truncate_file + "_received.txt")
+    )
     kwargs = get_json_data(truncate_file + "_args.json")
     os_parser = compliance.parser_map[network_os]
     assert "\n".join(os_parser(device_cfg).find_all_children(**kwargs)) == received_data
 
 
 @pytest.mark.parametrize("_file, network_os", find_children_w_parents_parameters)
-def test_find_children_w_parents(
-    _file, network_os, get_text_data, get_json_data
-):  # pylint: disable=redefined-outer-name
-    truncate_file = os.path.join(MOCK_DIR, "find_children_w_parents", _file[: -len(TXT_FILE)])
+def test_find_children_w_parents(_file, network_os, get_text_data, get_json_data):  # pylint: disable=redefined-outer-name
+    truncate_file = os.path.join(
+        MOCK_DIR, "find_children_w_parents", _file[: -len(TXT_FILE)]
+    )
 
     device_cfg = get_text_data(os.path.join(MOCK_DIR, "find_children_w_parents", _file))
-    received_data = get_text_data(os.path.join(MOCK_DIR, "find_children_w_parents", truncate_file + "_received.txt"))
+    received_data = get_text_data(
+        os.path.join(
+            MOCK_DIR, "find_children_w_parents", truncate_file + "_received.txt"
+        )
+    )
     kwargs = get_json_data(truncate_file + "_args.json")
     os_parser = compliance.parser_map[network_os]
-    assert "\n".join(os_parser(device_cfg).find_children_w_parents(**kwargs)) == received_data
+    assert (
+        "\n".join(os_parser(device_cfg).find_children_w_parents(**kwargs))
+        == received_data
+    )
 
 
 def test_incorrect_banner_ios():
@@ -78,5 +91,35 @@ def test_duplicate_line():
         "snmp-server community <<REPLACED>> RO SNMP_ACL_RO\n"
         "snmp-server community <<REPLACED>> RW SNMP_ACL_RW\n"
     )
-    with pytest.raises(IndexError, match=r".*This error is likely from a duplicate line detected.*"):
+    with pytest.raises(
+        IndexError, match=r".*This error is likely from a duplicate line detected.*"
+    ):
         compliance.parser_map["cisco_ios"](logging).config_lines  # pylint: disable=expression-not-assigned
+
+
+def test_banner_delimiter_iosxr():
+    banner_cfg = (
+        "banner motd ^This is the first line of a test banner.\n"
+        "This is the second line of a test banner.\n"
+        "This is the third line of a test banner.^\n"
+        "\n"
+        "ntp\n"
+        " server 192.0.2.1\n"
+        " server 192.0.2.2\n"
+    )
+    delimiter = compliance.parser_map["cisco_iosxr"](banner_cfg).delimiter
+    assert delimiter == "^"
+
+
+def test_banner_eof_delimiter_iosxr():
+    banner_cfg = (
+        "ntp\n"
+        " server 192.0.2.1\n"
+        " server 192.0.2.2\n"
+        "\n"
+        "banner motd ^This is the first line of a test banner.\n"
+        "This is the second line of a test banner.\n"
+        "This is the third line of a test banner.^\n"
+    )
+    delimiter = compliance.parser_map["cisco_iosxr"](banner_cfg).delimiter
+    assert delimiter == "^"


### PR DESCRIPTION
## New Pull Request

Have you:
- [x] Updated the README if necessary?
- [x] Updated any configuration settings?
- [x] Written a unit test?

## Change Notes
Added fix for finding banner delimiter when banner is at the end of the config ( IOSXR)
## Justification
Closes #614