### PR TITLE
Leading spaces

### DIFF
--- a/netutils/config/parser.py
+++ b/netutils/config/parser.py
@@ -1389,12 +1389,12 @@ class IOSXRConfigParser(CiscoConfigParser):
             ... ]
             True
         """
-        
+
         for index, line in enumerate(self.generator_config):
             current_spaces = self.get_leading_space_count(line) if line[0].isspace() else 0
-            
+
             if index == 0 and line[0].isspace():
-               line = self._remove_parents(line, current_spaces) 
+                line = self._remove_parents(line, current_spaces)
             if not line[0].isspace():
                 self._current_parents = ()
                 if self.is_banner_start(line):

--- a/netutils/config/parser.py
+++ b/netutils/config/parser.py
@@ -311,8 +311,11 @@ class BaseSpaceConfigParser(BaseConfigParser):
             ... ]
             True
         """
-        for line in self.generator_config:
-            if not line[0].isspace():
+        for index, line in enumerate(self.generator_config):
+            current_spaces = self.get_leading_space_count(line) if line[0].isspace() else 0
+            if index == 0 and line[0].isspace():
+                line = self._remove_parents(line, current_spaces)
+            elif not line[0].isspace():
                 self._current_parents = ()
                 if self.is_banner_start(line):
                     line = self._build_banner(line)  # type: ignore
@@ -985,8 +988,11 @@ class ASAConfigParser(CiscoConfigParser):
             ... ]
             True
         """
-        for line in self.generator_config:
-            if not line[0].isspace():
+        for index, line in enumerate(self.generator_config):
+            current_spaces = self.get_leading_space_count(line) if line[0].isspace() else 0
+            if index == 0 and line[0].isspace():
+                line = self._remove_parents(line, current_spaces)
+            elif not line[0].isspace():
                 self._current_parents = ()
             else:
                 previous_config = self.config_lines[-1]
@@ -1383,7 +1389,12 @@ class IOSXRConfigParser(CiscoConfigParser):
             ... ]
             True
         """
-        for line in self.generator_config:
+        
+        for index, line in enumerate(self.generator_config):
+            current_spaces = self.get_leading_space_count(line) if line[0].isspace() else 0
+            
+            if index == 0 and line[0].isspace():
+               line = self._remove_parents(line, current_spaces) 
             if not line[0].isspace():
                 self._current_parents = ()
                 if self.is_banner_start(line):

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -80,10 +80,10 @@ def test_duplicate_line():
     )
     with pytest.raises(IndexError, match=r".*This error is likely from a duplicate line detected.*"):
         compliance.parser_map["cisco_ios"](logging).config_lines  # pylint: disable=expression-not-assigned
-        
-        
+
+
 def test_leading_spaces_config_start():
-    logging = (            
+    logging = (
         "! Command: show running-config\n"
         " 24.1.4\n"
         "!\n"
@@ -93,9 +93,8 @@ def test_leading_spaces_config_start():
         "   no shutdown\n"
         "no service interface inactive port-id allocation disabled\n"
         "transceiver qsfp default-mode 4x10G\n"
-        )
+    )
     with pytest.raises(IndexError, match=r".*Validate the first line does not begin with a space.*"):
         compliance.parser_map["cisco_ios"](logging).config_lines  # pylint: disable=expression-not-assigned
         compliance.parser_map["arista_eos"](logging).config_lines  # pylint: disable=expression-not-assigned
         compliance.parser_map["cisco_xr"](logging).config_lines  # pylint: disable=expression-not-assigned
-        

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -80,3 +80,20 @@ def test_duplicate_line():
     )
     with pytest.raises(IndexError, match=r".*This error is likely from a duplicate line detected.*"):
         compliance.parser_map["cisco_ios"](logging).config_lines  # pylint: disable=expression-not-assigned
+def test_leading_spaces_config_start():
+    logging = (            
+        "! Command: show running-config\n"
+        " 24.1.4\n"
+        "!\n"
+        "no aaa root\n"
+        "!\n"
+        "management api http-commands\n"
+        "   no shutdown\n"
+        "no service interface inactive port-id allocation disabled\n"
+        "transceiver qsfp default-mode 4x10G\n"
+        )
+    with pytest.raises(IndexError, match=r".*Validate the first line does not begin with a space.*"):
+        compliance.parser_map["cisco_ios"](logging).config_lines  # pylint: disable=expression-not-assigned
+        compliance.parser_map["arista_eos"](logging).config_lines  # pylint: disable=expression-not-assigned
+        compliance.parser_map["cisco_xr"](logging).config_lines  # pylint: disable=expression-not-assigned
+        

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -80,6 +80,8 @@ def test_duplicate_line():
     )
     with pytest.raises(IndexError, match=r".*This error is likely from a duplicate line detected.*"):
         compliance.parser_map["cisco_ios"](logging).config_lines  # pylint: disable=expression-not-assigned
+        
+        
 def test_leading_spaces_config_start():
     logging = (            
         "! Command: show running-config\n"


### PR DESCRIPTION
Have you:
- [x] Updated the README if necessary?
- [x] Updated any configuration settings?
- [x] Written a unit test?

## Change Notes
Added a check to handle  whitespace at start of config inputs, avoiding the self.config_lines[-1] IndexError.
Added unit test(s) to cover configs with leading whitespaces.

## Justification
Closes #656
