### PR TITLE
fix: correctly handle `salt=0` in `encrypt_cisco_type7`

### DIFF
--- a/changes/741.fixed
+++ b/changes/741.fixed
@@ -1,0 +1,1 @@
+Fixed the logic error where `salt=0` was ignored in `encrypt_cisco_type7`

--- a/netutils/password.py
+++ b/netutils/password.py
@@ -292,7 +292,7 @@ def encrypt_cisco_type7(unencrypted_password: str, salt: t.Optional[int] = None)
     if len(unencrypted_password) > ENCRYPT_TYPE7_LENGTH:
         raise ValueError("Password must not exceed 25 characters.")
 
-    if not salt:
+    if salt is None:
         salt = random.randint(0, 15)  # noqa: S311
     # Start building the encrypted password - pre-pend the 2 decimal digit offset.
     encrypted_password = format(salt, "02d")

--- a/tests/unit/test_password.py
+++ b/tests/unit/test_password.py
@@ -86,6 +86,10 @@ ENCRYPT_CISCO_TYPE7 = [
         "sent": {"unencrypted_password": "cisco", "salt": 10},
         "received": "104D000A0618",
     },
+    {
+        "sent": {"unencrypted_password": "cisco", "salt": 0},
+        "received": "00071A150754",
+    },
 ]
 
 ENCRYPT_CISCO_TYPE9 = [


### PR DESCRIPTION
The function `encrypt_cisco_type7` was incorrectly handling the integer `0` as a missing argument because of the thruthiness check (`if not salt:`). This resulted in a random salt being used when the user explicitely requested salt `0`.

The condition has been updated to `if salt is None` to differentiate between a provided `0` and the default `None`.

Fixes #741