### PR TITLE
Add TenGigE interface mapping to BASE_INTERFACES

### DIFF
--- a/changes/841.added
+++ b/changes/841.added
@@ -1,0 +1,1 @@
+Added TenGigE to TenGigabitEthernet interface mapping in BASE_INTERFACES.

--- a/netutils/constants.py
+++ b/netutils/constants.py
@@ -119,6 +119,7 @@ BASE_INTERFACES = {
     "TenGigabitEthernet": "TenGigabitEthernet",
     "TenGigEthernet": "TenGigabitEthernet",
     "TenGigEth": "TenGigabitEthernet",
+    "TenGigE": "TenGigabitEthernet",
     "TenGig": "TenGigabitEthernet",
     "TeGig": "TenGigabitEthernet",
     "Ten": "TenGigabitEthernet",

--- a/tests/unit/test_interface.py
+++ b/tests/unit/test_interface.py
@@ -28,6 +28,7 @@ CANONICAL_INTERFACE_NAME = [
         "received": "TwoGigabitEthernet1/0/1",
     },
     {"sent": {"interface": "Tw1/0/1"}, "received": "TwoGigabitEthernet1/0/1"},
+    {"sent": {"interface": "TenGigE0/0/0/1"}, "received": "TenGigabitEthernet0/0/0/1"},
     {
         "sent": {"interface": "SuperFastEth 1/0/1", "addl_name_map": {"SuperFastEth": "SuperFastEthernet"}},
         "received": "SuperFastEthernet1/0/1",
@@ -154,6 +155,7 @@ ABBREVIATED_INTERFACE_NAME = [
         "received": "Tw1/0/1",
     },
     {"sent": {"interface": "Tw1/0/1"}, "received": "Tw1/0/1"},
+    {"sent": {"interface": "TenGigE0/0/0/1"}, "received": "Te0/0/0/1"},
     {
         "sent": {
             "interface": "SuperFastEth 1/0/1",


### PR DESCRIPTION
## New Pull Request

Have you:
- [x] Updated the README if necessary? (no README change needed)
- [ ] Updated any configuration settings?
- [x] Written a unit test?

## Change Notes

Closes #841

- Added `"TenGigE": "TenGigabitEthernet"` to `BASE_INTERFACES` in `netutils/constants.py`, grouped with the other TenGig variants.
- Added unit test cases for `canonical_interface_name` (`TenGigE0/0/0/1` → `TenGigabitEthernet0/0/0/1`) and `abbreviated_interface_name` (`TenGigE0/0/0/1` → `Te0/0/0/1`) in `tests/unit/test_interface.py`.
- Added changelog fragment `changes/841.added`.

No `REVERSE_MAPPING` change is needed: `abbreviated_interface_name` canonicalizes via `BASE_INTERFACES` first, then uses the existing `"TenGigabitEthernet": "Te"` entry.

## Justification

`TenGigE` is the literal interface name used by Cisco IOS-XR (e.g. `TenGigE0/0/0/1`), and it is the only Ethernet speed whose `...GigE` variant is missing from `BASE_INTERFACES` — `FortyGigE`, `FiftyGigE`, `HundredGigE`, `TwoHundredGigE`, and `FourHundredGigE` are all present. Today `canonical_interface_name("TenGigE0/0/0/1")` returns the input unchanged, forcing consumers to maintain an `addl_name_map` workaround.
