### PR TITLE
Fix NIST platform builder for unparseable versions

### DIFF
--- a/netutils/os_version.py
+++ b/netutils/os_version.py
@@ -258,9 +258,9 @@ def _basic_version_metadata(version: str) -> t.Dict[str, t.Any]:
     basic_regex: re.Pattern[str] = re.compile(
         r"""
         ^
-        (?P<major>0|[1-9]\d*)
+        0*(?P<major>\d+)
         \.
-        (?P<minor>0|[1-9]\d*)?
+        (?:0*(?P<minor>\d+))?
         .*$
         """,
         re.VERBOSE,

--- a/tests/unit/test_os_versions.py
+++ b/tests/unit/test_os_versions.py
@@ -50,6 +50,30 @@ PLATFORM_VERSION_METADATA = [
             "vendor_metadata": False,
         },
     },
+    {
+        "sent": {"vendor": "cisco", "platform": "ios", "version": "03.03.05SE"},
+        "received": {
+            "major": "3",
+            "minor": "3",
+            "vendor_metadata": False,
+        },
+    },
+    {
+        "sent": {"vendor": "cisco", "platform": "ios", "version": "3.03.05SE"},
+        "received": {
+            "major": "3",
+            "minor": "3",
+            "vendor_metadata": False,
+        },
+    },
+    {
+        "sent": {"vendor": "cisco", "platform": "ios", "version": "3.3.05SE"},
+        "received": {
+            "major": "3",
+            "minor": "3",
+            "vendor_metadata": False,
+        },
+    },
     # Juniper Junos uses a custom parser
     {
         "sent": {"vendor": "juniper", "platform": "junos", "version": "12.4R"},


### PR DESCRIPTION
Fixes #861

`version_metadata()` may return a dictionary containing keys that are not
defined on the dynamically generated platform dataclass when a version cannot
be parsed.

This change filters the returned metadata to fields defined by the platform
dataclass before constructing the object.

A regression test was added for the Cisco IOS version `03.03.05SE`.

Tests:
- 809 passed
- 10 skipped