### PR TITLE
Fix find_children_w_parents to include only real descendants

### DIFF
--- a/changes/836.fixed.md
+++ b/changes/836.fixed.md
@@ -1,0 +1,1 @@
+Fixed `find_children_w_parents` to only return the matched child line and its actual descendants, instead of every sibling line under the same top-level parent.

--- a/netutils/config/parser.py
+++ b/netutils/config/parser.py
@@ -416,20 +416,18 @@ class BaseSpaceConfigParser(BaseConfigParser):
             >>> print(bgp_conf)
             ['  address-family ipv4 unicast', '   neighbor 192.168.1.2 activate', '   network 172.17.1.0 mask']
         """
-        config = []
-        potential_parents = [
-            elem.parents[0]
-            for elem in self.build_config_relationship()
+        relationships = self.build_config_relationship()
+        matched_lines = {
+            elem.config_line
+            for elem in relationships
             if self._match_type_check(elem.config_line, child_pattern, match_type)
-        ]
-        for cfg_line in self.build_config_relationship():
-            parents = cfg_line.parents[0] if cfg_line.parents else None
-            if parents in potential_parents and self._match_type_check(
-                parents,  # type: ignore[arg-type]
-                parent_pattern,
-                match_type,
-            ):
-                config.append(cfg_line.config_line)
+            and elem.parents
+            and self._match_type_check(elem.parents[0], parent_pattern, match_type)
+        }
+        config = []
+        for elem in relationships:
+            if elem.config_line in matched_lines or any(parent in matched_lines for parent in elem.parents):
+                config.append(elem.config_line)
         return config
 
 

--- a/tests/unit/mock/config/parser/find_children_w_parents/cisco_ios/flat_siblings_args.json
+++ b/tests/unit/mock/config/parser/find_children_w_parents/cisco_ios/flat_siblings_args.json
@@ -1,0 +1,5 @@
+{
+    "parent_pattern": "context local",
+    "child_pattern": " logging",
+    "match_type": "regex"
+}

--- a/tests/unit/mock/config/parser/find_children_w_parents/cisco_ios/flat_siblings_received.txt
+++ b/tests/unit/mock/config/parser/find_children_w_parents/cisco_ios/flat_siblings_received.txt
@@ -1,0 +1,2 @@
+ logging something
+ logging something else

--- a/tests/unit/mock/config/parser/find_children_w_parents/cisco_ios/flat_siblings_sent.txt
+++ b/tests/unit/mock/config/parser/find_children_w_parents/cisco_ios/flat_siblings_sent.txt
@@ -1,0 +1,5 @@
+context local
+ something not logging
+ logging something
+ logging something else
+ something else not logging

--- a/tests/unit/mock/config/parser/find_children_w_parents/cisco_ios/ios_full_received.txt
+++ b/tests/unit/mock/config/parser/find_children_w_parents/cisco_ios/ios_full_received.txt
@@ -1,4 +1,3 @@
- contact-email-addr sch-smart-licensing@cisco.com
  profile "CiscoTAC-1"
   active
   destination transport-method http


### PR DESCRIPTION
Fixes #836 

find_children_w_parents grouped lines by their top level parent instead of the actual matched line. So matching one child pulled in every sibling under the same parent, even ones that don't match the pattern at all.

Example from the issue:
```python
parsed.find_children_w_parents(parent_pattern="context local", child_pattern=" logging", match_type="regex")
```
Before it also returned "something not logging". Now only the two logging lines come back.

Also updated the existing ios_full_received.txt fixture. It expected contact-email-addr to be included alongside profile "CiscoTAC-1", but contact-email-addr doesn't match the test's child_pattern at all, it's just a sibling under call-home. Same bug, just baked into the expected test output. Added a separate flat_siblings test case for the exact issue scenario.