### PR TITLE
Parse Aruba AOS-CX versions

### DIFF
--- a/netutils/os_version.py
+++ b/netutils/os_version.py
@@ -133,6 +133,28 @@ def compare_version_strict(current_version: str, comparison: str, target_version
     return _compare_version(current_version, comparison, target_version, "strict")
 
 
+def _hpe_arubaos_cx_version_metadata(version: str) -> t.Dict[str, t.Any]:
+    """Parse Aruba AOS-CX versions.
+
+    Examples:
+        >>> _hpe_arubaos_cx_version_metadata("FL.10.13.1161")
+        {'release': 'FL', 'major': '10', 'minor': '13', 'patch': '1161'}
+
+        >>> _hpe_arubaos_cx_version_metadata("GL.10.13.1090")
+        {'release': 'GL', 'major': '10', 'minor': '13', 'patch': '1090'}
+    """
+    regex = re.compile(
+        r"^(?P<release>[A-Z]{2})\.(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)$"
+    )
+
+    parsed_version = regex.match(version)
+
+    if parsed_version:
+        return parsed_version.groupdict()
+
+    return {"Error": "Unable to evaluate the version number entered."}
+
+
 def _juniper_junos_version_metadata(version: str) -> t.Dict[str, t.Any]:
     """Parses JunOS Version into usable bits matching JunOS Standards.
 
@@ -285,6 +307,9 @@ version_metadata_parsers = {
     "default": _basic_version_metadata,
     "juniper": {
         "junos": _juniper_junos_version_metadata,
+    },
+    "hpe": {
+        "arubaos-cx": _hpe_arubaos_cx_version_metadata,
     },
 }
 

--- a/tests/unit/test_os_versions.py
+++ b/tests/unit/test_os_versions.py
@@ -4,6 +4,7 @@ import pytest
 
 from netutils import os_version
 from netutils.constants import UPGRADE_PATHS
+from netutils.os_version import version_metadata
 
 LOOSE_VERSION = [
     {"sent": {"current_version": "10.1", "comparison": ">=", "target_version": "10.2"}, "received": False},
@@ -33,6 +34,35 @@ STRICT_VERSION = [
 ]
 
 PLATFORM_VERSION_METADATA = [
+    # ArubaOS-CX uses a custom version format
+    {
+        "sent": {
+            "vendor": "hpe",
+            "platform": "arubaos-cx",
+            "version": "FL.10.13.1161",
+        },
+        "received": {
+            "major": "10",
+            "minor": "13",
+            "patch": "1161",
+            "release": "FL",
+            "vendor_metadata": True,
+        },
+    },
+    {
+        "sent": {
+            "vendor": "hpe",
+            "platform": "arubaos-cx",
+            "version": "GL.10.13.1090",
+        },
+        "received": {
+            "major": "10",
+            "minor": "13",
+            "patch": "1090",
+            "release": "GL",
+            "vendor_metadata": True,
+        },
+    },
     # Cisco and Arista use the generic parsing
     {
         "sent": {"vendor": "cisco", "platform": "ios", "version": "15.7(2.0z)M"},


### PR DESCRIPTION
### Description

Add support for parsing Aruba AOS-CX operating system versions.

ArubaOS-CX uses a custom version format that is not handled correctly by the existing version parsing logic. This change adds the required parsing support so that AOS-CX versions can be correctly identified and normalized.

### Changes
Add parsing support for Aruba AOS-CX versions.
Handle the custom version format used by ArubaOS-CX.
Add the necessary logic to correctly extract and represent the OS version.

### Why

This improves Aruba AOS-CX support in netutils and allows consumers of the library to reliably work with AOS-CX version information.

### Testing

- Added/updated tests covering Aruba AOS-CX version parsing.
- Verified the expected version format is correctly parsed.